### PR TITLE
Defining Tests to Execute based on PhaseData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ ac_test_output/
 test-output/
 phased_output/
 .DS_Store
+/.idea/
+/*.iml

--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ By default we deactivate retry analyzer for the phased tests. However if you rea
 #### PHASED.TESTS.REPORT.BY.PHASE_GROUP
 By default we do not modify reports. Each step in a scenario is reported as is. We have introduced a "Report By Phase Group" functionality, which is activated with this property.
 
+## Executing a CONSUMER phase based on the PRODUCED Data
+Usually when your test code is in the repository of the product being tested, you will be having a delta in tests between two versions **N** & **N+1**. In such cases you will want to only execute the tests that exist in both versions. 
+
+For this, as of version 7.0.9, we have introduced the functionality that allows you to automatically select the phased tests that were executed in a previous phase. This means that when activated in a CONSUMER Phase, the selection is made based on the tests that were executed in the PRODUCER Phase. This functionality is activated when you pass or include the test group `PHASED_PRODUCED_TESTS`.
+
 ## Phase Contexts - Managing the Scenario Step Executions
 Although we try to keep the execution of a scenario like any other test scenario, we feel that it is useful to document how he state of a scenario works.
 
@@ -275,6 +280,9 @@ We now allow for a user to also include data providers in connection to Phased T
 A configuration check is done in the beginning. The phased test steps are checked and their arguments are compared to the number of data providers + the injected data provider for phased tests. If the number of arguments does not correspond to the total number of data providers, a `PhasedTestConfigurationException` is thrown right at the beginning.
 
 ## Release Notes
+### 7.0.9-SNAPSHOT
+- Implemented the new select tess to run based on the producer phase (#9)
+
 ### 7.0.8
 - Upgraded java version to Java 11
 - Activated sonar scans
@@ -287,7 +295,7 @@ A configuration check is done in the beginning. The phased test steps are checke
 ### 7.0.5
 - You can now define Phase setup methods. `@BeforePhase` & `@AfterPhase` can be set on a normal TestNG Before and After method. The method will then be executed in before or after a phase starts. (#40) 
 - We now allow for user defined data providers in a phased test. For the data provider to be considered, i needs to be declared at class level and not at method level. (#26)
--  We can now configure the reports to include the data providers.
+- We can now configure the reports to include the data providers.
 - We now throw an error if the arguments of the phased steps do not correspond to expected number of parameters (phased + user defined) (#28 & #27 & #38)
 - Solved issue with tests continuing in consumer mode even if their steps had not been executed in the producer phase (#43)
 
@@ -297,8 +305,8 @@ A configuration check is done in the beginning. The phased test steps are checke
 - Other issues corrected are : #20, #22, #23, #24, #25
 
 ### 7.0.3
-- #15 Renamed old produce/consume to produceInStep/consumeFromStep. The old produceWithKey/consumeWith key are now deprecated. Instead you should use produceWithKey/consumeWith 
-- #8  We an now export the phase cache at will. This is very useful for debugging or for Data Broker testing. Added a method PhasedTestManager.fetchExportFile which help return the selected export file 
+- Renamed old produce/consume to produceInStep/consumeFromStep. The old produceWithKey/consumeWith key are now deprecated. Instead you should use produceWithKey/consumeWith (#15) 
+- We can now export the phase cache at will. This is very useful for debugging or for Data Broker testing. Added a method PhasedTestManager.fetchExportFile which help return the selected export file (#8)
 
 ### 7.0.0
 - Migrated to TestNG 7.4

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestListener.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestListener.java
@@ -371,7 +371,7 @@ public class PhasedTestListener implements ITestListener, IAnnotationTransformer
                         .fetchDurationMillis(l_phasedScenarios.get(lt_phasedClass));
 
                 //When the phase test scenario was not a success
-                if (!PhasedTestManager.getPhasedCache().get(lt_phasedClass).equals(Boolean.TRUE.toString())) {
+                if (!PhasedTestManager.scenarioContext.get(lt_phasedClass).equals(Boolean.TRUE.toString())) {
 
                     //Delete all the passed steps : These steps are not remevant if we are merging the step results
                     Iterator<ITestResult> lt_passedTestIterator = context.getPassedTests().getAllResults()

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestListener.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestListener.java
@@ -371,7 +371,7 @@ public class PhasedTestListener implements ITestListener, IAnnotationTransformer
                         .fetchDurationMillis(l_phasedScenarios.get(lt_phasedClass));
 
                 //When the phase test scenario was not a success
-                if (!PhasedTestManager.scenarioContext.get(lt_phasedClass).equals(Boolean.TRUE.toString())) {
+                if (!PhasedTestManager.getScenarioContext().get(lt_phasedClass).equals(Boolean.TRUE.toString())) {
 
                     //Delete all the passed steps : These steps are not remevant if we are merging the step results
                     Iterator<ITestResult> lt_passedTestIterator = context.getPassedTests().getAllResults()

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestListener.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestListener.java
@@ -67,7 +67,7 @@ public class PhasedTestListener implements ITestListener, IAnnotationTransformer
         }
 
         //Inject the phased tests executed in the previous phase
-        for (XmlTest lt_tests : suites.get(0).getTests().stream()
+        for (XmlTest lt_xmlTest : suites.get(0).getTests().stream()
                 .filter(t -> t.getIncludedGroups().contains(PhasedTestManager.STD_GROUP_SELECT_TESTS_BY_PRODUCER))
                 .collect(Collectors.toList())) {
 
@@ -78,8 +78,8 @@ public class PhasedTestListener implements ITestListener, IAnnotationTransformer
                     .map(XmlClass::new).collect(Collectors.toSet());
 
             //add the original test classes
-            l_newXMLTests.addAll(lt_tests.getXmlClasses());
-            lt_tests.setXmlClasses(l_newXMLTests.stream().collect(Collectors.toList()));
+            l_newXMLTests.addAll(lt_xmlTest.getXmlClasses());
+            lt_xmlTest.setXmlClasses(l_newXMLTests.stream().collect(Collectors.toList()));
         }
 
         //Do we keep this?

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestListener.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestListener.java
@@ -36,7 +36,7 @@ public class PhasedTestListener implements ITestListener, IAnnotationTransformer
 
     @Override
     public void alter(List<XmlSuite> suites) {
-        /*** Import DataBroker ***/
+        // *** Import DataBroker ***
         String l_phasedDataBrokerClass = null;
         if (System.getProperties().containsKey(PhasedTestManager.PROP_PHASED_TEST_DATABROKER)) {
             l_phasedDataBrokerClass = System.getProperty(PhasedTestManager.PROP_PHASED_TEST_DATABROKER);
@@ -60,7 +60,7 @@ public class PhasedTestListener implements ITestListener, IAnnotationTransformer
             }
         }
 
-        /*** import context for consumer ***/
+        // *** import context for consumer ***
         //The second condition is there for testing purposes. You can bypass the file by filling the Test
         if (Phases.CONSUMER.isSelected() && PhasedTestManager.getPhasedCache().isEmpty()) {
             PhasedTestManager.importPhaseData();
@@ -79,7 +79,7 @@ public class PhasedTestListener implements ITestListener, IAnnotationTransformer
 
             //add the original test classes
             l_newXMLTests.addAll(lt_xmlTest.getXmlClasses());
-            lt_xmlTest.setXmlClasses(l_newXMLTests.stream().collect(Collectors.toList()));
+            lt_xmlTest.setXmlClasses(new ArrayList<>(l_newXMLTests));
         }
 
         //Do we keep this?
@@ -225,7 +225,6 @@ public class PhasedTestListener implements ITestListener, IAnnotationTransformer
             Field methodName = BaseTestMethod.class.getDeclaredField("m_methodName");
             methodName.setAccessible(true);
             methodName.set(in_testResult.getMethod(), l_newName);
-            String debug = in_testResult.getMethod().getMethodName();
         } catch (IllegalAccessException | NoSuchFieldException e) {
             throw new PhasedTestException(
                     "Error while changing the phased step name " + in_testResult.getName() + ".", e);
@@ -420,7 +419,7 @@ public class PhasedTestListener implements ITestListener, IAnnotationTransformer
 
                         if (PhasedTestManager.fetchScenarioName(lt_currentSkip).equals(lt_phasedClass)) {
 
-                            if (l_allSkipped == false) {
+                            if (!l_allSkipped) {
                                 log.debug(PhasedTestManager.PHASED_TEST_LOG_PREFIX + "Removing "
                                         + ClassPathParser.fetchFullName(lt_currentSkip)
                                         + " because there are unskipped values.");

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
@@ -1152,9 +1152,8 @@ public class PhasedTestManager {
      */
     public static void generateStepFailure(ITestResult in_failedTestResult) {
         if (in_failedTestResult.getStatus() != ITestResult.FAILURE) {
-            throw new IllegalArgumentException(
-                    "The given Test Result for " + in_failedTestResult.getMethod().getMethodName()
-                            + " is not a failed test.");
+            throw new IllegalArgumentException("The given Test Result for "
+                    + in_failedTestResult.getMethod().getMethodName() + " is not a failed test.");
         }
         Throwable l_thrownException = in_failedTestResult.getThrowable();
         StringBuilder sb = new StringBuilder();
@@ -1325,8 +1324,8 @@ public class PhasedTestManager {
             return lr_defaultReturnValue;
         }
 
-        if (l_dataproviderName.equals(PhasedTestManager.STD_PHASED_GROUP_SINGLE) || l_dataproviderName
-                .startsWith(PhasedTestManager.STD_PHASED_GROUP_PREFIX)) {
+        if (l_dataproviderName.equals(PhasedTestManager.STD_PHASED_GROUP_SINGLE)
+                || l_dataproviderName.startsWith(PhasedTestManager.STD_PHASED_GROUP_PREFIX)) {
             return lr_defaultReturnValue;
         }
 
@@ -1342,8 +1341,8 @@ public class PhasedTestManager {
         //Fetch the dataprovider method
         Method m = Arrays.asList(l_dataProviderClass.getDeclaredMethods()).stream()
                 .filter(a -> a.isAnnotationPresent(DataProvider.class))
-                .filter(f -> f.getDeclaredAnnotation(DataProvider.class).name().equals(l_dataproviderName)).findFirst()
-                .orElse(null);
+                .filter(f -> f.getDeclaredAnnotation(DataProvider.class).name().equals(l_dataproviderName))
+                .findFirst().orElse(null);
 
         if (m != null) {
             //In case of private data providers
@@ -1351,12 +1350,13 @@ public class PhasedTestManager {
         } else {
             throw new PhasedTestConfigurationException(
                     "No method found which matched the data provider class " + l_dataProviderClass.getTypeName()
-                            + " or data prrovider name " + l_dataproviderName);
+                            + " or data provider name " + l_dataproviderName);
         }
 
         try {
             return (Object[][]) m.invoke(l_dataProviderClass.newInstance(), new Object[0]);
-        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | InstantiationException e) {
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
+                | InstantiationException e) {
             log.error(PhasedTestManager.PHASED_TEST_LOG_PREFIX
                     + "Problem when fetching the user defined data providers.");
             throw new PhasedTestConfigurationException("Unable to call thee data provider method", e);
@@ -1418,10 +1418,11 @@ public class PhasedTestManager {
             Field exceptionMessage = l_changeClass.getDeclaredField("detailMessage");
             exceptionMessage.setAccessible(true);
             exceptionMessage.set(in_exception, in_newMessage);
-        } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
+        } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException
+                | SecurityException e) {
 
             throw new PhasedTestConfigurationException(
-                    "We were unable to chnage the message in the thrown exception " + in_exception.getClass().getName(),
+                    "We were unable to change the message in the thrown exception " + in_exception.getClass().getName(),
                     e);
         }
 

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
@@ -11,38 +11,25 @@
  */
 package com.adobe.campaign.tests.integro.phased;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.adobe.campaign.tests.integro.phased.utils.ClassPathParser;
+import com.adobe.campaign.tests.integro.phased.utils.GeneralTestUtils;
+import com.adobe.campaign.tests.integro.phased.utils.StackTraceManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testng.ITestResult;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.adobe.campaign.tests.integro.phased.utils.ClassPathParser;
-import com.adobe.campaign.tests.integro.phased.utils.GeneralTestUtils;
-import com.adobe.campaign.tests.integro.phased.utils.StackTraceManager;
+import java.io.*;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class PhasedTestManager {
 
+    protected static final String STD_GROUP_SELECT_TESTS_BY_PRODUCER = "PHASED_PRODUCED_TESTS";
     protected static final String STD_KEY_CLASS_SEPARATOR = "->";
 
     public static final String PHASED_TEST_LOG_PREFIX = "[Phased Testing] ";
@@ -55,6 +42,7 @@ public class PhasedTestManager {
     public static final String PROP_PHASED_TEST_DATABROKER = "PHASED.TESTS.DATABROKER";
     public static final String PROP_DISABLE_RETRY = "PHASED.TESTS.RETRY.DISABLED";
     public static final String PROP_MERGE_STEP_RESULTS = "PHASED.TESTS.REPORT.BY.PHASE_GROUP";
+    public static final String PROP_TEST_SELECTION_BY_PROPERTIES = "PROP.TEST.SELECTION.BY.PROPERTIES";
     private static final String PROP_SCENARIO_EXPORTED_PREFIX = "PHASED.TESTS.STORAGE.SCENARIO.PREFIX";
 
     public static final String DEFAULT_CACHE_DIR = "phased_output";
@@ -70,18 +58,16 @@ public class PhasedTestManager {
 
     /**
      * The different states a step can assume in a scenario
-     *
-     *
+     * <p>
+     * <p>
      * Author : gandomi
-     *
      */
     public enum ScenarioState {
         CONTINUE, SKIP_NORESULT, SKIP_PREVIOUS_FAILURE
-   }  
+    }
 
-  
     protected static Properties phasedCache = new Properties();
-    private static Properties scenarioContext = new Properties();
+    private static final Properties scenarioContext = new Properties();
 
     protected static Map<String, MethodMapping> methodMap = new HashMap<>();
 
@@ -91,8 +77,9 @@ public class PhasedTestManager {
 
     protected static Boolean mergedReportsActivated = Boolean.FALSE;
 
-    protected static final String SCENARIO_CONTEXT_PREFIX = System.getProperty(PROP_SCENARIO_EXPORTED_PREFIX,
-            "[TC]");
+    protected static Boolean selectTestsByProducerMode = Boolean.FALSE;
+
+    protected static final String SCENARIO_CONTEXT_PREFIX = System.getProperty(PROP_SCENARIO_EXPORTED_PREFIX, "[TC]");
 
     protected static class MergedReportData {
 
@@ -102,16 +89,13 @@ public class PhasedTestManager {
         /**
          * Allows you to defined the generated name when phased steps are merged
          * for a scenario. If nothing is set we use the phase group.
-         *
+         * <p>
          * Author : gandomi
          *
-         * @param in_prefix
-         *        A sorted set of report elements to be added as prefix to the
-         *        scenario name
-         * @param in_suffix
-         *        A sorted set of report elements to be added as suffix to the
-         *        scenario name
-         *
+         * @param in_prefix A sorted set of report elements to be added as prefix to the
+         *                  scenario name
+         * @param in_suffix A sorted set of report elements to be added as suffix to the
+         *                  scenario name
          */
         protected static void configureMergedReportName(LinkedHashSet<PhasedReportElements> in_prefix,
                 LinkedHashSet<PhasedReportElements> in_suffix) {
@@ -122,15 +106,14 @@ public class PhasedTestManager {
 
         /**
          * Resets the report configuration
-         *
+         * <p>
          * Author : gandomi
-         *
          */
         public static void resetReport() {
             prefix.clear();
             suffix.clear();
         }
-    };
+    }
 
     /**
      * @return the phasedCache
@@ -154,8 +137,7 @@ public class PhasedTestManager {
     }
 
     /**
-     * @param dataBroker
-     *        the dataBroker to set
+     * @param dataBroker the dataBroker to set
      */
     public static void setDataBroker(Object dataBroker) {
         PhasedTestManager.dataBroker = (PhasedDataBroker) dataBroker;
@@ -164,15 +146,12 @@ public class PhasedTestManager {
     /**
      * Initiaizes the databroker given the full class path of the implementation
      * of the interface {@code PhasedDataBroker}
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_classPath
-     *        The classpath for the implementation of the data broker
-     * @throws PhasedTestConfigurationException
-     *         Whenever there is a problem instantiating the Phased DataBroker
-     *         class
-     *
+     * @param in_classPath The classpath for the implementation of the data broker
+     * @throws PhasedTestConfigurationException Whenever there is a problem instantiating the Phased DataBroker
+     *                                          class
      */
     public static void setDataBroker(String in_classPath) throws PhasedTestConfigurationException {
         log.info(PHASED_TEST_LOG_PREFIX + "Setting Data broker with classpath " + in_classPath);
@@ -184,14 +163,11 @@ public class PhasedTestManager {
             l_dataBroker = l_dataBrokerImplementation.newInstance();
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
             throw new PhasedTestConfigurationException(
-                    "Error while fetching / instantiating the given PhasedDataBroker class " + in_classPath
-                            + ".",
-                    e);
+                    "Error while fetching / instantiating the given PhasedDataBroker class " + in_classPath + ".", e);
         }
 
         if (!(l_dataBroker instanceof PhasedDataBroker)) {
-            throw new PhasedTestConfigurationException(
-                    "The given class was not an instance of PhasedDataBroker");
+            throw new PhasedTestConfigurationException("The given class was not an instance of PhasedDataBroker");
         }
 
         setDataBroker(l_dataBroker);
@@ -200,10 +176,8 @@ public class PhasedTestManager {
 
     /**
      * This method clears the data broker
-     *
+     * <p>
      * Author : gandomi
-     *
-     *
      */
     public static void clearDataBroker() {
         dataBroker = null;
@@ -213,13 +187,11 @@ public class PhasedTestManager {
     /**
      * This method stores a phased test data in the cache. It will be stored
      * with the keys: "class, method, instance" and a value
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_storeValue
-     *        The value you want stored
+     * @param in_storeValue The value you want stored
      * @return The key that was used in storing the value
-     *
      */
     public static String produceInStep(String in_storeValue) {
         final String l_methodFullName = StackTraceManager.fetchCalledByFullName();
@@ -238,60 +210,49 @@ public class PhasedTestManager {
     /**
      * Stores a value with the given key. We include the class as prefix. By
      * default {@link #produceInStep(String)} should be preferred
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_storageKey
-     *        A string that is added to the generated key for identification of
-     *        the stored data
-     * @param in_storeValue
-     *        The value we want to store
+     * @param in_storageKey A string that is added to the generated key for identification of
+     *                      the stored data
+     * @param in_storeValue The value we want to store
      * @return The key that was used in storing the value
-     * 
      * @deprecated This method has been renamed. Please use
-     *             {@link #produce(String,String)} instead.
-     *
+     * {@link #produce(String, String)} instead.
      */
-    @Deprecated
-    public static String produceWithKey(String in_storageKey, String in_storeValue) {
+    @Deprecated public static String produceWithKey(String in_storageKey, String in_storeValue) {
         final String l_className = StackTraceManager.fetchCalledBy().getClassName();
-        final String l_fullId = generateStepKeyIdentity(StackTraceManager.fetchCalledByFullName(),
-                l_className, in_storageKey);
+        final String l_fullId = generateStepKeyIdentity(StackTraceManager.fetchCalledByFullName(), l_className,
+                in_storageKey);
         return storePhasedCache(l_fullId, in_storeValue);
     }
 
     /**
      * Stores a value with the given key. We include the class as prefix.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_storageKey
-     *        A string that is added to the generated key for identification of
-     *        the stored data
-     * @param in_storeValue
-     *        The value we want to store
+     * @param in_storageKey A string that is added to the generated key for identification of
+     *                      the stored data
+     * @param in_storeValue The value we want to store
      * @return The key that was used in storing the value
-     * 
      */
     public static String produce(String in_storageKey, String in_storeValue) {
         final String l_className = StackTraceManager.fetchCalledBy().getClassName();
-        final String l_fullId = generateStepKeyIdentity(StackTraceManager.fetchCalledByFullName(),
-                l_className, in_storageKey);
+        final String l_fullId = generateStepKeyIdentity(StackTraceManager.fetchCalledByFullName(), l_className,
+                in_storageKey);
         return storePhasedCache(l_fullId, in_storeValue);
     }
 
     /**
      * This method generates the identifier for a producer/consumer used for
      * storing in the cache
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_idInPhaseContext
-     *        The id of the step in the context
-     * @param in_storageKey
-     *        An additional identifier for storing the data
+     * @param in_idInPhaseContext The id of the step in the context
+     * @param in_storageKey       An additional identifier for storing the data
      * @return The identity of the storage key as stored in the cache
-     *
      */
     protected static String generateStepKeyIdentity(final String in_idInPhaseContext, String in_storageKey) {
 
@@ -300,21 +261,17 @@ public class PhasedTestManager {
 
     /**
      * This method generates the identifier for a producer/consumer
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_idInPhaseContext
-     *        The id of the step in the context
-     * @param in_idPrefixToStore
-     *        The prefix of the full name for storing values. Usually the class
-     *        full name
-     * @param in_storageKey
-     *        An additional identifier for storing the data
+     * @param in_idInPhaseContext The id of the step in the context
+     * @param in_idPrefixToStore  The prefix of the full name for storing values. Usually the class
+     *                            full name
+     * @param in_storageKey       An additional identifier for storing the data
      * @return The identity of the storage key as stored in the cache
-     *
      */
-    protected static String generateStepKeyIdentity(final String in_idInPhaseContext,
-            final String in_idPrefixToStore, String in_storageKey) {
+    protected static String generateStepKeyIdentity(final String in_idInPhaseContext, final String in_idPrefixToStore,
+            String in_storageKey) {
         StringBuilder sb = new StringBuilder(in_idPrefixToStore);
 
         if (phaseContext.containsKey(in_idInPhaseContext)) {
@@ -333,11 +290,10 @@ public class PhasedTestManager {
 
     /**
      * This method generates the identifier for a producer/consumer
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_idInPhaseContext
-     *        The id of the step in the context
+     * @param in_idInPhaseContext The id of the step in the context
      * @return The identity of the storage key as stored in the cache
      */
     protected static String generateStepKeyIdentity(String in_idInPhaseContext) {
@@ -346,15 +302,12 @@ public class PhasedTestManager {
 
     /**
      * Stores a value in the cache
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_storeKey
-     *        The key to be used for storing the value
-     * @param in_storeValue
-     *        The value to be stored
+     * @param in_storeKey   The key to be used for storing the value
+     * @param in_storeValue The value to be stored
      * @return The key used for storing the value
-     *
      */
     private static String storePhasedCache(final String in_storeKey, String in_storeValue) {
         if (phasedCache.containsKey(in_storeKey)) {
@@ -370,14 +323,12 @@ public class PhasedTestManager {
      * test. It will fetch a Phased Test data with the method/test that called
      * this method. This method is to be used if you have produced your Phased
      * Data using {@link #produceInStep(String)}
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_stepName
-     *        The step name aka method name (not class name nor arguments) that
-     *        stored a value in the current scenario
+     * @param in_stepName The step name aka method name (not class name nor arguments) that
+     *                    stored a value in the current scenario
      * @return The value store by the method
-     *
      */
     public static String consumeFromStep(String in_stepName) {
         StackTraceElement l_calledElement = StackTraceManager.fetchCalledBy();
@@ -401,21 +352,19 @@ public class PhasedTestManager {
 
     /**
      * Returns the value stored in the context, and requested by a test.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_consumableKey
-     *        The key identifier for the consumable
-     * @param in_calledByTest
-     *        The string representation of the test accessing the consumable
+     * @param in_consumableKey The key identifier for the consumable
+     * @param in_calledByTest  The string representation of the test accessing the consumable
      * @return The value for the given consumable. If not found a
-     *         PhasedTestException is thrown
-     *
+     * PhasedTestException is thrown
      */
     public static String fetchStoredConsumable(final String in_consumableKey, String in_calledByTest) {
         if (!phasedCache.containsKey(in_consumableKey)) {
-            throw new PhasedTestException("The given consumable " + in_consumableKey + " requested by "
-                    + in_calledByTest + " was not available.");
+            throw new PhasedTestException(
+                    "The given consumable " + in_consumableKey + " requested by " + in_calledByTest
+                            + " was not available.");
         }
 
         return phasedCache.getProperty(in_consumableKey);
@@ -424,19 +373,15 @@ public class PhasedTestManager {
     /**
      * Given a step in the Phased Test it fetches the value committed for that
      * test.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_storageKey
-     *        A key that was used to store the value in this scenario
+     * @param in_storageKey A key that was used to store the value in this scenario
      * @return The value that was stored
-     * 
      * @deprecated This method has been renamed. Please use
-     *             {@link #consume(String)} instead
-     *
+     * {@link #consume(String)} instead
      */
-    @Deprecated
-    public static String consumeWithKey(String in_storageKey) {
+    @Deprecated public static String consumeWithKey(String in_storageKey) {
         final StackTraceElement l_fetchCalledBy = StackTraceManager.fetchCalledBy();
 
         String l_realKey = generateStepKeyIdentity(StackTraceManager.fetchCalledByFullName(),
@@ -448,13 +393,11 @@ public class PhasedTestManager {
     /**
      * Given a step in the Phased Test it fetches the value committed for that
      * test.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_storageKey
-     *        A key that was used to store the value in this scenario
+     * @param in_storageKey A key that was used to store the value in this scenario
      * @return The value that was stored
-     * 
      */
     public static String consume(String in_storageKey) {
         final StackTraceElement l_fetchCalledBy = StackTraceManager.fetchCalledBy();
@@ -467,10 +410,8 @@ public class PhasedTestManager {
 
     /**
      * cleans the cache of the PhasedManager
-     *
+     * <p>
      * Author : gandomi
-     *
-     *
      */
     protected static void clearCache() {
         phasedCache.clear();
@@ -483,11 +424,10 @@ public class PhasedTestManager {
 
     /**
      * Exports the cache into a standard PhasedTest property file.
-     *
+     * <p>
      * Author : gandomi
      *
      * @return The file that was used for storing the phase cache
-     *
      */
     public static File exportPhaseData() {
 
@@ -498,11 +438,10 @@ public class PhasedTestManager {
 
     /**
      * Returns the export file that will be used for exporting the PhaseCache
-     *
+     * <p>
      * Author : gandomi
      *
      * @return A file that matches the location of the export file
-     *
      */
     public static File fetchExportFile() {
         File l_exportCacheFile;
@@ -517,21 +456,18 @@ public class PhasedTestManager {
 
     /**
      * Exports the Phase cache and the scenario context into the given file
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_file
-     *        that will contain the phase cache and scenario contexts
+     * @param in_file that will contain the phase cache and scenario contexts
      * @return The file used for storing the Phase Context.
-     *
      */
     protected static File exportContext(File in_file) {
 
         log.info(PHASED_TEST_LOG_PREFIX + " Exporting Phased Testing data to " + in_file.getPath());
 
         Properties lt_transformedScenarios = new Properties();
-        scenarioContext.forEach(
-                (key, value) -> lt_transformedScenarios.put(attachContextFlag(key.toString()), value));
+        scenarioContext.forEach((key, value) -> lt_transformedScenarios.put(attachContextFlag(key.toString()), value));
 
         try (FileWriter fw = new FileWriter(in_file)) {
 
@@ -555,14 +491,12 @@ public class PhasedTestManager {
     /**
      * Imports a file and stored the properties in the phased cache and in the
      * scenario context.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_phasedTestFile
-     *        A file that contains the phase cache data from a previous phase
+     * @param in_phasedTestFile A file that contains the phase cache data from a previous phase
      * @return A Properties object with the phase cache data from the previous
-     *         phase
-     *
+     * phase
      */
     protected static Properties importContext(File in_phasedTestFile) {
         log.info(PHASED_TEST_LOG_PREFIX + "Importing phase cache.");
@@ -578,13 +512,12 @@ public class PhasedTestManager {
         }
 
         //Import produced data into phase cache
-        lr_importedProperties.stringPropertyNames().stream()
-                .filter(k -> !k.startsWith(SCENARIO_CONTEXT_PREFIX))
+        lr_importedProperties.stringPropertyNames().stream().filter(k -> !k.startsWith(SCENARIO_CONTEXT_PREFIX))
                 .forEach(fk -> phasedCache.put(fk, lr_importedProperties.get(fk)));
 
         //Import scenario contexts into scenario context
-        lr_importedProperties.stringPropertyNames().stream()
-                .filter(k -> k.startsWith(SCENARIO_CONTEXT_PREFIX)).forEach(fk -> scenarioContext
+        lr_importedProperties.stringPropertyNames().stream().filter(k -> k.startsWith(SCENARIO_CONTEXT_PREFIX)).forEach(
+                fk -> scenarioContext
                         .put(fk.substring(SCENARIO_CONTEXT_PREFIX.length()), lr_importedProperties.get(fk)));
 
         return lr_importedProperties;
@@ -593,12 +526,11 @@ public class PhasedTestManager {
     /**
      * Loads the Phased Test data from the standard location which is by default
      * {@value #DEFAULT_CACHE_DIR}/{@value #STD_STORE_DIR}/{@value #STD_STORE_FILE}
-     *
+     * <p>
      * Author : gandomi
      *
      * @return A Properties object with the phase cache data from the previous
-     *         phase
-     *
+     * phase
      */
     protected static Properties importPhaseData() {
         File l_importCacheFile = null;
@@ -609,8 +541,7 @@ public class PhasedTestManager {
                 l_importCacheFile = new File(System.getProperty(PROP_PHASED_DATA_PATH));
 
             } else {
-                l_importCacheFile = new File(GeneralTestUtils.fetchCacheDirectory(STD_STORE_DIR),
-                        STD_STORE_FILE);
+                l_importCacheFile = new File(GeneralTestUtils.fetchCacheDirectory(STD_STORE_DIR), STD_STORE_FILE);
                 log.warn(PHASED_TEST_LOG_PREFIX + " The system property " + PROP_PHASED_DATA_PATH
                         + " not set. Fetching Phased Test data from " + l_importCacheFile.getPath());
             }
@@ -624,14 +555,12 @@ public class PhasedTestManager {
 
     /**
      * Calculates the data providers for the current method and test context
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_method
-     *        The step/method for which we want to fond out the data provider
+     * @param in_method The step/method for which we want to fond out the data provider
      * @return A two-dimensional array of all the data providers attached to the
-     *         current step/method
-     *
+     * current step/method
      */
     public static Object[][] fetchProvidersShuffled(Method in_method) {
         String l_methodFullName = ClassPathParser.fetchFullName(in_method);
@@ -642,15 +571,13 @@ public class PhasedTestManager {
      * Returns the provider for shuffling tests. In general the values are
      * Shuffle group prefix + Nr of steps before the Phase Event and the number
      * of steps after the event.
-     * 
+     * <p>
      * Author : gandomi
      *
-     * @param in_methodFullName
-     *        The full name of the method used for identifying it in the phase
-     *        context
+     * @param in_methodFullName The full name of the method used for identifying it in the phase
+     *                          context
      * @return A two-dimensional array of all the data providers attached to the
-     *         current step/method
-     *
+     * current step/method
      */
     public static Object[][] fetchProvidersShuffled(String in_methodFullName) {
 
@@ -661,18 +588,15 @@ public class PhasedTestManager {
      * Returns the provider for shuffling tests. In general the values are
      * Shuffle group prefix + Nr of steps before the Phase Event and the number
      * of steps after the event.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_methodFullName
-     *        The full name of the method used for identifying it in the phase
-     *        context
-     * @param in_phasedState
-     *        The phase state for which we should retrieve the parameters. The
-     *        parameters will be different based on the phase.
+     * @param in_methodFullName The full name of the method used for identifying it in the phase
+     *                          context
+     * @param in_phasedState    The phase state for which we should retrieve the parameters. The
+     *                          parameters will be different based on the phase.
      * @return A two-dimensional array of all the data providers attached to the
-     *         current step/method
-     *
+     * current step/method
      */
     public static Object[][] fetchProvidersShuffled(String in_methodFullName, Phases in_phasedState) {
 
@@ -681,9 +605,8 @@ public class PhasedTestManager {
 
         for (int rows = 0; rows < l_methodMapping.nrOfProviders; rows++) {
 
-            int lt_nrBeforePhase = in_phasedState.equals(Phases.PRODUCER)
-                    ? (l_methodMapping.totalClassMethods - rows)
-                    : rows;
+            int lt_nrBeforePhase = in_phasedState.equals(Phases.PRODUCER) ? (l_methodMapping.totalClassMethods
+                    - rows) : rows;
 
             int lt_nrAfterPhase = l_methodMapping.totalClassMethods - lt_nrBeforePhase;
 
@@ -702,21 +625,18 @@ public class PhasedTestManager {
         //Merge
         Object[][] lr_dataProviders = dataProvidersCrossJoin(l_objectArrayPhased, l_userDefinedDataProviders);
 
-        log.debug(PhasedTestManager.PHASED_TEST_LOG_PREFIX + "returning provider for method "
-                + in_methodFullName);
+        log.debug(PhasedTestManager.PHASED_TEST_LOG_PREFIX + "returning provider for method " + in_methodFullName);
         return lr_dataProviders;
     }
 
     /**
      * Returns the data provider for a single phase
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_method
-     *        The method/step for which we want to get the data providers for
+     * @param in_method The method/step for which we want to get the data providers for
      * @return An array containing the data providers for the method. Otherwise
-     *         an empty array
-     *
+     * an empty array
      */
     public static Object[] fetchProvidersSingle(Method in_method) {
         log.debug("Returning provider for method " + ClassPathParser.fetchFullName(in_method));
@@ -730,8 +650,8 @@ public class PhasedTestManager {
             return new Object[] { STD_PHASED_GROUP_SINGLE };
         }
 
-        if (Phases.NON_PHASED.isSelected()
-                && in_method.getDeclaringClass().getAnnotation(PhasedTest.class).executeInactive()) {
+        if (Phases.NON_PHASED.isSelected() && in_method.getDeclaringClass().getAnnotation(PhasedTest.class)
+                .executeInactive()) {
             return new Object[] { STD_PHASED_GROUP_SINGLE };
         }
 
@@ -740,17 +660,14 @@ public class PhasedTestManager {
 
     /**
      * This method calculates how often a class should be run.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_classMethodMap
-     *        A map of a class and it is methods (A scenario and its steps)
+     * @param in_classMethodMap A map of a class and it is methods (A scenario and its steps)
      * @return A map letting us know that for a the given method how often it
-     *         will be executed in the current phase
-     *
+     * will be executed in the current phase
      */
-    public static Map<String, MethodMapping> generatePhasedProviders(
-            Map<Class, List<String>> in_classMethodMap) {
+    public static Map<String, MethodMapping> generatePhasedProviders(Map<Class, List<String>> in_classMethodMap) {
 
         return generatePhasedProviders(in_classMethodMap, Phases.getCurrentPhase());
 
@@ -759,19 +676,16 @@ public class PhasedTestManager {
     /**
      * This method calculates how often a scenario should be run, given the
      * steps/methods it has.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_classMethodMap
-     *        A map of a class and it is methods (A scenario and its steps)
-     * @param in_phaseState
-     *        The phase in which we are
+     * @param in_classMethodMap A map of a class and it is methods (A scenario and its steps)
+     * @param in_phaseState     The phase in which we are
      * @return A map letting us know that for a the given method how often it
-     *         will be executed in the current phase
-     *
+     * will be executed in the current phase
      */
-    public static Map<String, MethodMapping> generatePhasedProviders(
-            Map<Class, List<String>> in_classMethodMap, Phases in_phaseState) {
+    public static Map<String, MethodMapping> generatePhasedProviders(Map<Class, List<String>> in_classMethodMap,
+            Phases in_phaseState) {
         methodMap = new HashMap<>();
 
         for (Class lt_class : in_classMethodMap.keySet()) {
@@ -783,8 +697,9 @@ public class PhasedTestManager {
             }
 
             for (int i = 0; i < in_classMethodMap.get(lt_class).size(); i++) {
-                methodMap.put(lt_methodList.get(i), new MethodMapping(lt_class,
-                        in_classMethodMap.get(lt_class).size() - i, in_classMethodMap.get(lt_class).size()));
+                methodMap.put(lt_methodList.get(i),
+                        new MethodMapping(lt_class, in_classMethodMap.get(lt_class).size() - i,
+                                in_classMethodMap.get(lt_class).size()));
 
             }
         }
@@ -794,14 +709,11 @@ public class PhasedTestManager {
 
     /**
      * Updates the context with the method and its current Phase Group ID
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_methodFullName
-     *        The full name of the method
-     * @param in_phasedGroupId
-     *        The Id of the phase group
-     *
+     * @param in_methodFullName The full name of the method
+     * @param in_phasedGroupId  The Id of the phase group
      */
     public static void storePhasedContext(String in_methodFullName, String in_phasedGroupId) {
         phaseContext.put(in_methodFullName, in_phasedGroupId);
@@ -810,35 +722,28 @@ public class PhasedTestManager {
 
     /**
      * For testing purposes only. Used when we want to test the consumer
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_testMethod
-     *        A test method
-     * @param in_phaseGroup
-     *        A phase group Id
-     * @param in_storedData
-     *        The data to be stored for the scenario step
+     * @param in_testMethod A test method
+     * @param in_phaseGroup A phase group Id
+     * @param in_storedData The data to be stored for the scenario step
      * @return The key used to store the value in the cache
      */
     protected static String storeTestData(Method in_testMethod, String in_phaseGroup, String in_storedData) {
         phaseContext.put(ClassPathParser.fetchFullName(in_testMethod), in_phaseGroup);
-        return storePhasedCache(generateStepKeyIdentity(ClassPathParser.fetchFullName(in_testMethod)),
-                in_storedData);
+        return storePhasedCache(generateStepKeyIdentity(ClassPathParser.fetchFullName(in_testMethod)), in_storedData);
 
     }
 
     /**
      * For testing purposes only. Used when we want to test the consumer
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_class
-     *        A test method
-     * @param in_phaseGroup
-     *        A phase group Id
-     * @param in_storedData
-     *        The data to be stored for the scenario step
+     * @param in_class      A test method
+     * @param in_phaseGroup A phase group Id
+     * @param in_storedData The data to be stored for the scenario step
      * @return The key used to store the value in the cache
      */
     protected static String storeTestData(Class in_class, String in_phaseGroup, String in_storedData) {
@@ -854,13 +759,11 @@ public class PhasedTestManager {
      * Basically lets us know if we execute the given method in producer mode.
      * We look at the attribute value phaseEnd. This method is specifically for
      * the Single Mode.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_method
-     *        The method/step we want to know its phase location
+     * @param in_method The method/step we want to know its phase location
      * @return true if the step is anywhere before the phase limit
-     *
      */
     public static boolean isExecutedInProducerMode(Method in_method) {
 
@@ -869,8 +772,7 @@ public class PhasedTestManager {
             List<Method> l_myMethods = Arrays.asList(l_declaringClass.getMethods()).stream()
                     .filter(f -> PhasedTestManager.isPhasedTest(f)).collect(Collectors.toList());
 
-            Comparator<Method> compareMethodByName = (Method m1, Method m2) -> m1.getName()
-                    .compareTo(m2.getName());
+            Comparator<Method> compareMethodByName = (Method m1, Method m2) -> m1.getName().compareTo(m2.getName());
 
             Collections.sort(l_myMethods, compareMethodByName);
 
@@ -890,14 +792,12 @@ public class PhasedTestManager {
 
     /**
      * Checks if the phase step is the last item in the current phase
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_method
-     *        The method/step which we want to know if it is the last step in
-     *        the current phase
+     * @param in_method The method/step which we want to know if it is the last step in
+     *                  the current phase
      * @return True if the test is before or in the phase End.
-     *
      */
     protected static boolean isPhaseLimit(Method in_method) {
 
@@ -908,13 +808,11 @@ public class PhasedTestManager {
      * This method tells us if the method is a valid phased test. This is done
      * by seeing if the annotation PhasedStep is on the method, and if the
      * annotation PhasedTest is on the class
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_method
-     *        Any test method that is being executed
+     * @param in_method Any test method that is being executed
      * @return true if The annotations PhasedTest and PhasedStep are present
-     *
      */
     public static boolean isPhasedTest(Method in_method) {
         return isPhasedTest(in_method.getDeclaringClass());
@@ -922,27 +820,23 @@ public class PhasedTestManager {
 
     /**
      * This method lets us know if the class is a PhasedTestClass
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_class
-     *        Any class that contains tests
+     * @param in_class Any class that contains tests
      * @return True if the class is a phased test scenario
-     *
      */
-    @SuppressWarnings("unchecked")
-    public static boolean isPhasedTest(Class in_class) {
+    @SuppressWarnings("unchecked") public static boolean isPhasedTest(Class in_class) {
         return in_class.isAnnotationPresent(PhasedTest.class);
     }
 
     /**
      * This method lets us know if the steps in a PhasedTest are to be executed
      * consequently in two phases
-     * 
-     * @param in_method
-     *        Any test method
+     *
+     * @param in_method Any test method
      * @return True if the test step/method is part of a SingleRun Phase Test
-     *         scenario
+     * scenario
      */
     protected static boolean isPhasedTestSingleMode(Method in_method) {
         return isPhasedTest(in_method) && !isPhasedTestShuffledMode(in_method);
@@ -951,9 +845,8 @@ public class PhasedTestManager {
     /**
      * This method lets us know if the steps in a PhasedTest are to be executed
      * consequently in two phases
-     * 
-     * @param in_class
-     *        Any class that contains tests
+     *
+     * @param in_class Any class that contains tests
      * @return True if the test class is a SingleRun Phase Test scenario
      */
     protected static boolean isPhasedTestSingleMode(Class in_class) {
@@ -964,11 +857,10 @@ public class PhasedTestManager {
      * This method lets us know if the steps in a PhasedTest are to be executed
      * in a shuffled manner. For a test with 3 steps the test will be executed 6
      * times in total
-     * 
-     * @param in_method
-     *        A test method
+     *
+     * @param in_method A test method
      * @return True if the given test method/step is part of a Shuffled Phased
-     *         Test scenario
+     * Test scenario
      */
     protected static boolean isPhasedTestShuffledMode(Method in_method) {
         return isPhasedTest(in_method) && isPhasedTestShuffledMode(in_method.getDeclaringClass());
@@ -978,31 +870,28 @@ public class PhasedTestManager {
      * This method lets us know if the steps in a PhasedTest are to be executed
      * in a Shuffled manner. For a test with 3 steps the test will be executed 6
      * times in total
-     * 
-     * @param in_class
-     *        A test class/scenario
+     *
+     * @param in_class A test class/scenario
      * @return True if the given test scenario is a Shuffled Phased Test
-     *         scenario
+     * scenario
      */
     protected static boolean isPhasedTestShuffledMode(Class in_class) {
-        return isPhasedTest(in_class) && ((PhasedTest) in_class.getAnnotation(PhasedTest.class)).canShuffle()
-                && Phases.getCurrentPhase().hasSplittingEvent();
+        return isPhasedTest(in_class) && ((PhasedTest) in_class.getAnnotation(PhasedTest.class)).canShuffle() && Phases
+                .getCurrentPhase().hasSplittingEvent();
     }
 
     /**
      * This method provides an ID for the scenario given the ITestNGResult. This
      * is assembled using the Classname + the PhaseGroup
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_testNGResult
-     *        A TestNG Test Result object
+     * @param in_testNGResult A TestNG Test Result object
      * @return The identity of the scenario
-     *
      */
     public static String fetchScenarioName(ITestResult in_testNGResult) {
-        StringBuilder sb = new StringBuilder(in_testNGResult.getMethod().getConstructorOrMethod().getMethod()
-                .getDeclaringClass().getTypeName());
+        StringBuilder sb = new StringBuilder(
+                in_testNGResult.getMethod().getConstructorOrMethod().getMethod().getDeclaringClass().getTypeName());
         return sb.append(ClassPathParser.fetchParameterValues(in_testNGResult)).toString();
     }
 
@@ -1010,15 +899,13 @@ public class PhasedTestManager {
      * This method logs the stage result of the Phased Test Group. The key will
      * be the class including the phase test group. It allows us to know if the
      * test is allowed to continue.
-     * 
+     * <p>
      * Once the context is logged as false for a test it re
-     s false
-     *
+     * s false
+     * <p>
      * Author : gandomi
      *
-     * @param in_testResult
-     *        The test result
-     *
+     * @param in_testResult The test result
      */
     public static void scenarioStateStore(ITestResult in_testResult) {
 
@@ -1028,17 +915,15 @@ public class PhasedTestManager {
         if (scenarioContext.containsKey(l_scenarioName)) {
 
             //If the phase context is true we check if the state for the scenario should change. Otherwise we interrupt the tests
-            if (scenarioContext.get(l_scenarioName).equals(Boolean.TRUE.toString())
-                    || scenarioContext.get(l_scenarioName).equals(l_stepName)) {
+            if (scenarioContext.get(l_scenarioName).equals(Boolean.TRUE.toString()) || scenarioContext
+                    .get(l_scenarioName).equals(l_stepName)) {
                 scenarioContext.put(l_scenarioName,
-                        in_testResult.getStatus() == ITestResult.SUCCESS ? Boolean.TRUE.toString()
-                                : l_stepName);
+                        in_testResult.getStatus() == ITestResult.SUCCESS ? Boolean.TRUE.toString() : l_stepName);
             }
 
         } else {
             scenarioContext.put(l_scenarioName,
-                    (in_testResult.getStatus() == ITestResult.SUCCESS) ? Boolean.TRUE.toString()
-                            : l_stepName);
+                    (in_testResult.getStatus() == ITestResult.SUCCESS) ? Boolean.TRUE.toString() : l_stepName);
         }
 
     }
@@ -1055,7 +940,7 @@ public class PhasedTestManager {
      * we will continue.
      * <p>
      * There is one Exception. If the cause of the failure is the current test.
-     * 
+     *
      * <table>
      * <caption>Use Cases for Scenario States</caption>
      * <tr>
@@ -1122,18 +1007,16 @@ public class PhasedTestManager {
      * <td>SKIP</td>
      * </tr>
      * </table>
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_testResult
-     *        The test result
+     * @param in_testResult The test result
      * @return A decision regarding the continuation of the scenario. We also
-     *         provide the reasons as to why the skipping happens.
-     *         ScenarioState.SKIP_NORESULT returns when we should skip due to
-     *         non-execution of a previous step. SKIP_PREVIOUS_FAILURE is
-     *         returned when we are supposed o skip because of a failure in a
-     *         previous step
-     *
+     * provide the reasons as to why the skipping happens.
+     * ScenarioState.SKIP_NORESULT returns when we should skip due to
+     * non-execution of a previous step. SKIP_PREVIOUS_FAILURE is
+     * returned when we are supposed o skip because of a failure in a
+     * previous step
      */
     public static ScenarioState scenarioStateDecision(ITestResult in_testResult) {
         final String l_scenarioName = fetchScenarioName(in_testResult);
@@ -1150,29 +1033,26 @@ public class PhasedTestManager {
         //If scenario has not yet been executed in the current phase 
         if (!getScenarioContext().containsKey(l_scenarioName)) {
             //True only if we are executing end to end 0_X
-            return hasStepsExecutedInProducer(in_testResult) ? ScenarioState.SKIP_NORESULT
-                    : ScenarioState.CONTINUE;
+            return hasStepsExecutedInProducer(in_testResult) ? ScenarioState.SKIP_NORESULT : ScenarioState.CONTINUE;
         }
 
         if (getScenarioContext().get(l_scenarioName).equals(ClassPathParser.fetchFullName(in_testResult))) {
             return ScenarioState.CONTINUE;
         }
 
-        return getScenarioContext().get(l_scenarioName).equals(Boolean.TRUE.toString()) ? ScenarioState.CONTINUE
-                : ScenarioState.SKIP_PREVIOUS_FAILURE;
+        return getScenarioContext().get(l_scenarioName)
+                .equals(Boolean.TRUE.toString()) ? ScenarioState.CONTINUE : ScenarioState.SKIP_PREVIOUS_FAILURE;
     }
 
     /**
      * Creates a standard report name. I.e. it provides a name as how the test
      * scenario and phased group should be represented.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_testResult
-     *        A TestRessult object
+     * @param in_testResult A TestRessult object
      * @return A string prefixed with the scenario name and suffixed with the
-     *         phaseGroup
-     *
+     * phaseGroup
      */
     public static String fetchTestNameForReport(ITestResult in_testResult) {
 
@@ -1206,28 +1086,25 @@ public class PhasedTestManager {
      * This method calculates the duration in milliseconds for a phased test
      * scenario. Given a List of ITestNGResult related to that scenario, it
      * makes a sum of the start and end milliseconds of its steps.
-     * 
+     * <p>
      * Throws an {@link IllegalArgumentException} when the given List is null or
      * empty.
-     *
+     * <p>
      * Throws an {@link IllegalArgumentException} when the given List is not
      * from the same Phase group or scenario
-     * 
+     * <p>
      * Author : gandomi
      *
-     * @param in_resultList
-     *        A List of ITestNGResults related to a given scenario
+     * @param in_resultList A List of ITestNGResults related to a given scenario
      * @return A long value representing the duration in milliseconds
-     *
      */
     protected static long fetchDurationMillis(List<ITestResult> in_resultList) {
         if (in_resultList == null || in_resultList.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "The given result list of TestNGResults is either null or empty");
+            throw new IllegalArgumentException("The given result list of TestNGResults is either null or empty");
         }
 
-        if (!in_resultList.stream().allMatch(
-                t -> t.getMethod().getRealClass().equals(in_resultList.get(0).getMethod().getRealClass()))) {
+        if (!in_resultList.stream()
+                .allMatch(t -> t.getMethod().getRealClass().equals(in_resultList.get(0).getMethod().getRealClass()))) {
             throw new IllegalArgumentException("The given tests are not of the same Class");
         }
 
@@ -1242,19 +1119,17 @@ public class PhasedTestManager {
     /**
      * This method creates a step name by prefixing the step name with the phase
      * group
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param result
-     *        The TestNGResult object
+     * @param result The TestNGResult object
      * @return A string representation of the test name
-     *
      */
     protected static String fetchPhasedStepName(ITestResult result) {
         if (result.getParameters().length == 0) {
-            throw new IllegalArgumentException("No parameters found. The given test result for test "
-                    + ClassPathParser.fetchFullName(result)
-                    + " does not seem to have been part of a Phased Test");
+            throw new IllegalArgumentException(
+                    "No parameters found. The given test result for test " + ClassPathParser.fetchFullName(result)
+                            + " does not seem to have been part of a Phased Test");
         }
 
         StringBuilder sb = new StringBuilder(concatenateParameterArray(result.getParameters()));
@@ -1270,17 +1145,16 @@ public class PhasedTestManager {
      * <p>
      * An {@link IllegalArgumentException} is thrown if the given
      * in_failedTestResult is not failed.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_failedTestResult
-     *        The exception we want to wrap.
-     *
+     * @param in_failedTestResult The exception we want to wrap.
      */
     public static void generateStepFailure(ITestResult in_failedTestResult) {
         if (in_failedTestResult.getStatus() != ITestResult.FAILURE) {
-            throw new IllegalArgumentException("The given Test Result for "
-                    + in_failedTestResult.getMethod().getMethodName() + " is not a failed test.");
+            throw new IllegalArgumentException(
+                    "The given Test Result for " + in_failedTestResult.getMethod().getMethodName()
+                            + " is not a failed test.");
         }
         Throwable l_thrownException = in_failedTestResult.getThrowable();
         StringBuilder sb = new StringBuilder();
@@ -1333,15 +1207,12 @@ public class PhasedTestManager {
      * <td>Y</td>
      * </tr>
      * </table>
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_providerSeriesLeft
-     *        The data provider data which is used on the left side of the join
-     * @param in_providerSeriesRight
-     *        The data provider data which is used on the left right of the join
+     * @param in_providerSeriesLeft  The data provider data which is used on the left side of the join
+     * @param in_providerSeriesRight The data provider data which is used on the left right of the join
      * @return A merged array that contains elements of both arrays
-     *
      */
     public static Object[][] dataProvidersCrossJoin(Object[][] in_providerSeriesLeft,
             Object[][] in_providerSeriesRight) {
@@ -1372,16 +1243,13 @@ public class PhasedTestManager {
     /**
      * Allows you to defined the generated name when phased steps are merged for
      * a scenario. If nothing is set we use the phase group.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_prefix
-     *        A sorted set of report elements to be added as prefix to the
-     *        scenario name
-     * @param in_suffix
-     *        A sorted set of report elements to be added as suffix to the
-     *        scenario name
-     *
+     * @param in_prefix A sorted set of report elements to be added as prefix to the
+     *                  scenario name
+     * @param in_suffix A sorted set of report elements to be added as suffix to the
+     *                  scenario name
      */
     public static void configureMergedReportName(LinkedHashSet<PhasedReportElements> in_prefix,
             LinkedHashSet<PhasedReportElements> in_suffix) {
@@ -1390,7 +1258,7 @@ public class PhasedTestManager {
 
     /**
      * With this method we activate the merged reports
-     *
+     * <p>
      * Author : gandomi
      */
     public static void activateMergedReports() {
@@ -1400,7 +1268,7 @@ public class PhasedTestManager {
 
     /**
      * With this method we activate the merged reports
-     *
+     * <p>
      * Author : gandomi
      */
     public static void deactivateMergedReports() {
@@ -1408,15 +1276,35 @@ public class PhasedTestManager {
     }
 
     /**
+     * With this method we activate the selection of tests by the stored phase context
+     * <p>
+     * Author : gandomi
+     */
+    public static void activateTestSelectionByProducerMode() {
+        selectTestsByProducerMode = true;
+    }
+
+    /**
+     * With this method we activate the selection of tests by the stored phase context
+     * <p>
+     * Author : gandomi
+     */
+    public static void deactivateTestSelectionByProducerMode() {
+        selectTestsByProducerMode = false;
+    }
+
+    public static Boolean isTestsSelectedByProducerMode() {
+        return selectTestsByProducerMode;
+    }
+
+    /**
      * This method fetches the declared DataProvider values related to a class
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_phasedTestClass
-     *        A Phased Test class
+     * @param in_phasedTestClass A Phased Test class
      * @return The data providers attached to the class. An empty array is
-     *         returned if there is no data provider defined at a class level
-     *
+     * returned if there is no data provider defined at a class level
      */
     protected static Object[][] fetchDataProviderValues(Class<?> in_phasedTestClass) {
 
@@ -1437,8 +1325,8 @@ public class PhasedTestManager {
             return lr_defaultReturnValue;
         }
 
-        if (l_dataproviderName.equals(PhasedTestManager.STD_PHASED_GROUP_SINGLE)
-                || l_dataproviderName.startsWith(PhasedTestManager.STD_PHASED_GROUP_PREFIX)) {
+        if (l_dataproviderName.equals(PhasedTestManager.STD_PHASED_GROUP_SINGLE) || l_dataproviderName
+                .startsWith(PhasedTestManager.STD_PHASED_GROUP_PREFIX)) {
             return lr_defaultReturnValue;
         }
 
@@ -1454,23 +1342,21 @@ public class PhasedTestManager {
         //Fetch the dataprovider method
         Method m = Arrays.asList(l_dataProviderClass.getDeclaredMethods()).stream()
                 .filter(a -> a.isAnnotationPresent(DataProvider.class))
-                .filter(f -> f.getDeclaredAnnotation(DataProvider.class).name().equals(l_dataproviderName))
-                .findFirst().orElse(null);
+                .filter(f -> f.getDeclaredAnnotation(DataProvider.class).name().equals(l_dataproviderName)).findFirst()
+                .orElse(null);
 
         if (m != null) {
             //In case of private data providers
             m.setAccessible(true);
         } else {
             throw new PhasedTestConfigurationException(
-                    "No method found which matched the data provider class "
-                            + l_dataProviderClass.getTypeName() + " or data prrovider name "
-                            + l_dataproviderName);
+                    "No method found which matched the data provider class " + l_dataProviderClass.getTypeName()
+                            + " or data prrovider name " + l_dataproviderName);
         }
 
         try {
             return (Object[][]) m.invoke(l_dataProviderClass.newInstance(), new Object[0]);
-        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException
-                | InstantiationException e) {
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | InstantiationException e) {
             log.error(PhasedTestManager.PHASED_TEST_LOG_PREFIX
                     + "Problem when fetching the user defined data providers.");
             throw new PhasedTestConfigurationException("Unable to call thee data provider method", e);
@@ -1479,13 +1365,11 @@ public class PhasedTestManager {
 
     /**
      * Given an array of Objects, we concatenate them into a simple String
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_values
-     *        an array of objects that can be transformed to a string
+     * @param in_values an array of objects that can be transformed to a string
      * @return a concatenation of the values. Otherwise empty String
-     *
      */
     protected static String concatenateParameterArray(Object[] in_values) {
         StringBuilder sb = new StringBuilder();
@@ -1503,11 +1387,10 @@ public class PhasedTestManager {
 
     /**
      * Checks if the merged report is activated
-     *
+     * <p>
      * Author : gandomi
      *
      * @return TRUE Iff the value is true otherwise it returns false
-     *
      */
     public static boolean isMergedReportsActivated() {
         return mergedReportsActivated == Boolean.TRUE;
@@ -1515,14 +1398,11 @@ public class PhasedTestManager {
 
     /**
      * This method changes the message within the given Exception
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_exception
-     *        An exception that has been thrown.
-     * @param in_newMessage
-     *        The new message that should replace the old one
-     *
+     * @param in_exception  An exception that has been thrown.
+     * @param in_newMessage The new message that should replace the old one
      */
     public static void changeExceptionMessage(Throwable in_exception, String in_newMessage) {
 
@@ -1538,12 +1418,10 @@ public class PhasedTestManager {
             Field exceptionMessage = l_changeClass.getDeclaredField("detailMessage");
             exceptionMessage.setAccessible(true);
             exceptionMessage.set(in_exception, in_newMessage);
-        } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException
-                | SecurityException e) {
+        } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException | SecurityException e) {
 
             throw new PhasedTestConfigurationException(
-                    "We were unable to chnage the message in the thrown exception "
-                            + in_exception.getClass().getName(),
+                    "We were unable to chnage the message in the thrown exception " + in_exception.getClass().getName(),
                     e);
         }
 
@@ -1552,14 +1430,12 @@ public class PhasedTestManager {
     /**
      * Given a phased test method and and its phase group, lets you know if it
      * has ssteps executed in the producer phase
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_testResult
-     *        A TestNG Test result
+     * @param in_testResult A TestNG Test result
      * @return true if we are in consumer, and we are not a 0_X phase group that
-     *         is executed end to end in the consumer phase
-     *
+     * is executed end to end in the consumer phase
      */
     public static boolean hasStepsExecutedInProducer(ITestResult in_testResult) {
         return hasStepsExecutedInProducer(in_testResult, Phases.getCurrentPhase());
@@ -1569,16 +1445,13 @@ public class PhasedTestManager {
     /**
      * Given a phased test method and and its phase group, lets you know if it
      * has ssteps executed in the producer phase
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_testResult
-     *        A TestNG Test result
-     * @param in_phase
-     *        The phase in which we are currently.
+     * @param in_testResult A TestNG Test result
+     * @param in_phase      The phase in which we are currently.
      * @return true if we are in consumer, and we are not a 0_X phase group that
-     *         is executed end to end in the consumer phase
-     *
+     * is executed end to end in the consumer phase
      */
     public static boolean hasStepsExecutedInProducer(ITestResult in_testResult, Phases in_phase) {
         return (in_phase.equals(Phases.CONSUMER) && (fetchNrOfStepsBeforePhaseChange(in_testResult) > 0));
@@ -1587,14 +1460,12 @@ public class PhasedTestManager {
     /**
      * Given a string representing the phase group, returns the number of steps
      * planned before a phase change
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_testResult
-     *        A test result object containing the necessary analysis daata
+     * @param in_testResult A test result object containing the necessary analysis daata
      * @return The number of steps planned before a phase change. If we are
-     *         non-phased we return 0
-     *
+     * non-phased we return 0
      */
     public static Integer fetchNrOfStepsBeforePhaseChange(ITestResult in_testResult) {
 
@@ -1603,8 +1474,7 @@ public class PhasedTestManager {
             final String l_phaseGroup = in_testResult.getParameters()[0].toString();
 
             if (!l_phaseGroup.startsWith(STD_PHASED_GROUP_PREFIX)) {
-                throw new PhasedTestException(
-                        "The phase group of this test does not seem correct: " + l_phaseGroup);
+                throw new PhasedTestException("The phase group of this test does not seem correct: " + l_phaseGroup);
             }
 
             String l_numberString = l_phaseGroup.substring(STD_PHASED_GROUP_PREFIX.length(),
@@ -1619,11 +1489,10 @@ public class PhasedTestManager {
     /**
      * Extracts all the tests that have been executed before the current phase.
      * This will later be used to create the test list to be executed
-     *
+     * <p>
      * Author : gandomi
      *
      * @return A set of class paths
-     *
      */
     public static Set<String> fetchExecutedPhasedClasses() {
 
@@ -1634,13 +1503,11 @@ public class PhasedTestManager {
     /**
      * Given a scenario we extract the class covering it. If the given class is
      * not a phased execution, we do not transform the scring.
-     *
+     * <p>
      * Author : gandomi
      *
-     * @param in_scenario
-     *        The execued scenario. This will include the phase group
+     * @param in_scenario The execued scenario. This will include the phase group
      * @return The class path of the phased scenario
-     *
      */
     public static String fetchClassFromScenarioContext(String in_scenario) {
         if (in_scenario == null) {

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
@@ -769,8 +769,8 @@ public class PhasedTestManager {
 
         if (PhasedTestManager.isPhasedTestSingleMode(in_method)) {
             final Class<?> l_declaringClass = in_method.getDeclaringClass();
-            List<Method> l_myMethods = Arrays.asList(l_declaringClass.getMethods()).stream()
-                    .filter(f -> PhasedTestManager.isPhasedTest(f)).collect(Collectors.toList());
+            List<Method> l_myMethods = Arrays.stream(l_declaringClass.getMethods())
+                    .filter(PhasedTestManager::isPhasedTest).collect(Collectors.toList());
 
             Comparator<Method> compareMethodByName = (Method m1, Method m2) -> m1.getName().compareTo(m2.getName());
 
@@ -1240,29 +1240,12 @@ public class PhasedTestManager {
     }
 
     /**
-     * Allows you to defined the generated name when phased steps are merged for
-     * a scenario. If nothing is set we use the phase group.
-     * <p>
-     * Author : gandomi
-     *
-     * @param in_prefix A sorted set of report elements to be added as prefix to the
-     *                  scenario name
-     * @param in_suffix A sorted set of report elements to be added as suffix to the
-     *                  scenario name
-     */
-    public static void configureMergedReportName(LinkedHashSet<PhasedReportElements> in_prefix,
-            LinkedHashSet<PhasedReportElements> in_suffix) {
-        MergedReportData.configureMergedReportName(in_prefix, in_suffix);
-    }
-
-    /**
      * With this method we activate the merged reports
      * <p>
      * Author : gandomi
      */
     public static void activateMergedReports() {
         mergedReportsActivated = true;
-
     }
 
     /**
@@ -1339,7 +1322,7 @@ public class PhasedTestManager {
         }
 
         //Fetch the dataprovider method
-        Method m = Arrays.asList(l_dataProviderClass.getDeclaredMethods()).stream()
+        Method m = Arrays.stream(l_dataProviderClass.getDeclaredMethods())
                 .filter(a -> a.isAnnotationPresent(DataProvider.class))
                 .filter(f -> f.getDeclaredAnnotation(DataProvider.class).name().equals(l_dataproviderName))
                 .findFirst().orElse(null);

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
@@ -518,9 +518,8 @@ public class PhasedTestManager {
         log.info(PHASED_TEST_LOG_PREFIX + " Exporting Phased Testing data to " + in_file.getPath());
 
         Properties lt_transformedScenarios = new Properties();
-        scenarioContext.forEach((key, value) -> {
-            lt_transformedScenarios.put(attachContextFlag(key.toString()), value);
-        });
+        scenarioContext.forEach(
+                (key, value) -> lt_transformedScenarios.put(attachContextFlag(key.toString()), value));
 
         try (FileWriter fw = new FileWriter(in_file)) {
 
@@ -1541,7 +1540,7 @@ public class PhasedTestManager {
      */
     public static Set<String> fetchExecutedPhasedClasses() {
 
-        return getScenarioContext().stringPropertyNames().stream().map(c -> fetchClassFromScenarioContext(c))
+        return getScenarioContext().stringPropertyNames().stream().map(PhasedTestManager::fetchClassFromScenarioContext)
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/utils/GeneralTestUtils.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/utils/GeneralTestUtils.java
@@ -17,6 +17,8 @@ import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
+import java.util.stream.Collectors;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -108,11 +110,12 @@ public class GeneralTestUtils {
      *
      * Author : gandomi
      *
-     * @param in_fileToDelete A file that we want to delee.
+     * @param in_fileToDelete
+     *        A file that we want to delee.
      *
      */
     protected static void deleteFile(File in_fileToDelete) {
-        if (in_fileToDelete.exists() ) {
+        if (in_fileToDelete.exists()) {
             log.debug("Deleting cache File");
             if (!in_fileToDelete.delete()) {
                 throw new IllegalStateException("Unable to delete file " + in_fileToDelete.getPath());
@@ -175,6 +178,22 @@ public class GeneralTestUtils {
         }
 
         return lr_fileContent.toString();
+    }
+
+    /**
+     * This method fetches the lines with actual data of a given file. In this
+     * case we also filter the commented out lines
+     * 
+     * Author : gandomi
+     *
+     * @param in_resourceFile
+     *        A file object
+     * @return A list where each entry is a an uncommented line in the file
+     *
+     */
+    public static List<String> fetchFileContentDataLines(File in_resourceFile) {
+
+        return fetchFileContentLines(in_resourceFile).stream().filter(l -> !l.startsWith("#")).collect(Collectors.toList());
     }
 
 }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/PhasedTestManagerTests.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/PhasedTestManagerTests.java
@@ -25,6 +25,7 @@ import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_B_NoInActive;
 import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_F_Shuffle;
 import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_H_ShuffledClass;
 import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_H_ShuffledClassWithError;
+import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_H_SingleClass;
 import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_K_ShuffledClass_noproviders;
 import com.adobe.campaign.tests.integro.phased.data.dp.PhasedSeries_L_DPDefinitionInexistant;
 import com.adobe.campaign.tests.integro.phased.data.dp.PhasedSeries_L_PROVIDER;
@@ -52,6 +53,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+
 import org.hamcrest.Matchers;
 import org.mockito.Mockito;
 
@@ -200,11 +203,11 @@ public class PhasedTestManagerTests {
 
         assertThat(PhasedTestManager.phasedCache.size(), Matchers.greaterThan(0));
 
-        PhasedTestManager.scenarioContext.put("A", "B");
-        assertThat(PhasedTestManager.scenarioContext.size(), Matchers.greaterThan(0));
+        PhasedTestManager.getScenarioContext().put("A", "B");
+        assertThat(PhasedTestManager.getScenarioContext().size(), Matchers.greaterThan(0));
         PhasedTestManager.clearCache();
         assertThat(PhasedTestManager.phasedCache.size(), equalTo(0));
-        assertThat(PhasedTestManager.scenarioContext.size(), Matchers.equalTo(0));
+        assertThat(PhasedTestManager.getScenarioContext().size(), Matchers.equalTo(0));
     }
 
     @Test
@@ -247,14 +250,10 @@ public class PhasedTestManagerTests {
         }
 
         assertThat("We should find our property", prop.size(), equalTo(2));
-        assertThat("We should find our property", prop
-                .containsKey(l_stepName));
-        assertThat("We should find our property",
-                prop.getProperty(
-                        l_stepName),
-                equalTo("Hello"));
+        assertThat("We should find our property", prop.containsKey(l_stepName));
+        assertThat("We should find our property", prop.getProperty(l_stepName), equalTo("Hello"));
 
-        final String l_storedScenarioContext = PhasedTestManager.SCENARIO_CONTEXT_PREFIX+ scenarioId;
+        final String l_storedScenarioContext = PhasedTestManager.SCENARIO_CONTEXT_PREFIX + scenarioId;
         final String l_storedScenarioName = l_storedScenarioContext;
         assertThat("We should find our scenario", prop.containsKey(l_storedScenarioContext));
 
@@ -581,7 +580,7 @@ public class PhasedTestManagerTests {
         assertThat("We should find our property", l_phasedTestdata.containsKey(l_stepId));
         assertThat("We should find our property", l_phasedTestdata.getProperty(l_stepId), equalTo("Hello"));
 
-        final String l_exporteedIdForScenario = PhasedTestManager.SCENARIO_CONTEXT_PREFIX+l_scenarioId;
+        final String l_exporteedIdForScenario = PhasedTestManager.SCENARIO_CONTEXT_PREFIX + l_scenarioId;
         assertThat("We should find our scenario", l_phasedTestdata.containsKey(l_exporteedIdForScenario));
         assertThat("We should find our property", l_phasedTestdata.getProperty(l_exporteedIdForScenario),
                 equalTo(Boolean.TRUE.toString()));
@@ -589,17 +588,22 @@ public class PhasedTestManagerTests {
         //Checking that the phasedCache is imported correctly
         assertThat("phaseCache : We should find our property", PhasedTestManager.phasedCache.size(),
                 equalTo(1));
-        assertThat("phaseCache : We should find our property", PhasedTestManager.phasedCache.containsKey(l_stepId));
-        assertThat("phaseCache : We should find our property value", PhasedTestManager.phasedCache.getProperty(l_stepId),
-                equalTo("Hello"));
-        assertThat("phaseCache : We should not have stored the find our property", !PhasedTestManager.phasedCache.containsKey(l_scenarioId));
-        
+        assertThat("phaseCache : We should find our property",
+                PhasedTestManager.phasedCache.containsKey(l_stepId));
+        assertThat("phaseCache : We should find our property value",
+                PhasedTestManager.phasedCache.getProperty(l_stepId), equalTo("Hello"));
+        assertThat("phaseCache : We should not have stored the find our property",
+                !PhasedTestManager.phasedCache.containsKey(l_scenarioId));
+
         //Checking that the scenarioContext is imported correctly
-        assertThat("scenarioConext: We should find our scenario", PhasedTestManager.scenarioContext.containsKey(l_scenarioId));
-        assertThat("scenarioConext: We should find our property", PhasedTestManager.scenarioContext.getProperty(l_scenarioId),
+        assertThat("scenarioConext: We should find our scenario",
+                PhasedTestManager.getScenarioContext().containsKey(l_scenarioId));
+        assertThat("scenarioConext: We should find our property",
+                PhasedTestManager.getScenarioContext().getProperty(l_scenarioId),
                 equalTo(Boolean.TRUE.toString()));
-        assertThat("scenarioConext: We should not have stored the find our property", !PhasedTestManager.scenarioContext.containsKey(l_stepId));
-        
+        assertThat("scenarioConext: We should not have stored the find our property",
+                !PhasedTestManager.getScenarioContext().containsKey(l_stepId));
+
     }
 
     @Test
@@ -1228,10 +1232,10 @@ public class PhasedTestManagerTests {
         assertThat("The context should have not been stored in the phasedCache",
                 !PhasedTestManager.phasedCache.containsKey(l_scenarioName));
         assertThat("The context should have been stored in the scenarioContext",
-                PhasedTestManager.scenarioContext.containsKey(l_scenarioName));
+                PhasedTestManager.getScenarioContext().containsKey(l_scenarioName));
 
-        assertThat("We should havee the correct value", PhasedTestManager.scenarioContext.get(l_scenarioName),
-                equalTo(Boolean.TRUE.toString()));
+        assertThat("We should havee the correct value",
+                PhasedTestManager.getScenarioContext().get(l_scenarioName), equalTo(Boolean.TRUE.toString()));
 
         assertThat("We should be able to continue with the phase group",
                 PhasedTestManager.scenarioStateContinue(l_itr));
@@ -1387,9 +1391,10 @@ public class PhasedTestManagerTests {
         String l_scenarioName = PhasedTestManager.fetchScenarioName(l_itr);
 
         assertThat("The context should have been stored",
-                PhasedTestManager.scenarioContext.containsKey(l_scenarioName));
+                PhasedTestManager.getScenarioContext().containsKey(l_scenarioName));
 
-        assertThat("We should have the correct value", PhasedTestManager.scenarioContext.get(l_scenarioName),
+        assertThat("We should have the correct value",
+                PhasedTestManager.getScenarioContext().get(l_scenarioName),
                 equalTo(ClassPathParser.fetchFullName(l_itr)));
 
         assertThat("We should be able to continue with the phase group",
@@ -1425,7 +1430,7 @@ public class PhasedTestManagerTests {
                 PhasedTestManager.scenarioStateContinue(l_itr));
 
         String l_name = PhasedTestManager.fetchScenarioName(l_itr);
-        assertThat("We should have the correct value", PhasedTestManager.scenarioContext.get(l_name),
+        assertThat("We should have the correct value", PhasedTestManager.getScenarioContext().get(l_name),
                 equalTo(ClassPathParser.fetchFullName(l_itr)));
 
     }
@@ -1455,7 +1460,8 @@ public class PhasedTestManagerTests {
         PhasedTestManager.scenarioStateStore(l_itr);
 
         String l_scenarioName = PhasedTestManager.fetchScenarioName(l_itr);
-        assertThat("We should have the correct value", PhasedTestManager.scenarioContext.get(l_scenarioName),
+        assertThat("We should have the correct value",
+                PhasedTestManager.getScenarioContext().get(l_scenarioName),
                 equalTo(ClassPathParser.fetchFullName(l_itr)));
 
         final Method l_myTestWithOneArg2 = PhasedSeries_H_ShuffledClassWithError.class.getMethod("step3",
@@ -1477,7 +1483,7 @@ public class PhasedTestManagerTests {
         PhasedTestManager.scenarioStateStore(l_itr2);
 
         assertThat("The step that caused the failure should not change",
-                PhasedTestManager.scenarioContext.get(l_scenarioName),
+                PhasedTestManager.getScenarioContext().get(l_scenarioName),
                 equalTo(ClassPathParser.fetchFullName(l_itr)));
 
     }
@@ -2540,6 +2546,50 @@ public class PhasedTestManagerTests {
         Phases.CONSUMER.activate();
         assertThrows(PhasedTestException.class,
                 () -> PhasedTestManager.fetchNrOfStepsBeforePhaseChange(l_itr));
+
+    }
+
+    @Test
+    public void extractTestNameFromScenarioContext() {
+        String l_scenario1 = PhasedTestManager.storeTestData(PhasedSeries_K_ShuffledClass_noproviders.class,
+                PhasedTestManager.STD_PHASED_GROUP_SINGLE, Boolean.TRUE.toString());
+
+        assertThat("We should get the correct class",
+                PhasedTestManager.fetchClassFromScenarioContext(l_scenario1),
+                Matchers.equalTo(PhasedSeries_K_ShuffledClass_noproviders.class.getTypeName()));
+
+        assertThat("We should get the correct class",
+                PhasedTestManager.fetchClassFromScenarioContext(
+                        PhasedSeries_K_ShuffledClass_noproviders.class.getTypeName()),
+                Matchers.equalTo(PhasedSeries_K_ShuffledClass_noproviders.class.getTypeName()));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> PhasedTestManager.fetchClassFromScenarioContext(null));
+    }
+
+    @Test
+    public void extractTestsFromCache() throws NoSuchMethodException, SecurityException {
+        PhasedTestManager.storeTestData(PhasedSeries_K_ShuffledClass_noproviders.class,
+                PhasedTestManager.STD_PHASED_GROUP_PREFIX + "1_2", Boolean.TRUE.toString());
+
+        PhasedTestManager.storeTestData(PhasedSeries_H_SingleClass.class,
+                PhasedTestManager.STD_PHASED_GROUP_PREFIX + "2_1", Boolean.FALSE.toString());
+
+        PhasedTestManager.storeTestData(PhasedSeries_H_SingleClass.class,
+                PhasedTestManager.STD_PHASED_GROUP_SINGLE, Boolean.FALSE.toString());
+
+        PhasedTestManager.storeTestData(PhasedTestManagerTests.class.getMethod("testStorageMethod"),
+                PhasedTestManager.STD_PHASED_GROUP_PREFIX + "2_3", "A");
+
+        Set<String> l_setOfClasses = PhasedTestManager.fetchExecutedPhasedClasses();
+
+        assertThat("We should have a result", l_setOfClasses, Matchers.notNullValue());
+
+        assertThat("We should two entries", l_setOfClasses.size(), Matchers.equalTo(2));
+
+        assertThat("We should two entries", l_setOfClasses,
+                Matchers.containsInAnyOrder(PhasedSeries_K_ShuffledClass_noproviders.class.getTypeName(),
+                        PhasedSeries_H_SingleClass.class.getTypeName()));
 
     }
 

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/PhasedTestManagerTests.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/PhasedTestManagerTests.java
@@ -67,6 +67,7 @@ public class PhasedTestManagerTests {
         System.clearProperty(PhasedTestManager.PROP_SELECTED_PHASE);
         System.clearProperty(PhasedTestManager.PROP_PHASED_TEST_DATABROKER);
         System.clearProperty(PhasedTestManager.PROP_MERGE_STEP_RESULTS);
+        System.clearProperty(PhasedTestManager.PROP_TEST_SELECTION_BY_PROPERTIES);
 
         PhasedTestManager.deactivateMergedReports();
         PhasedTestManager.MergedReportData.resetReport();
@@ -3217,5 +3218,4 @@ public class PhasedTestManagerTests {
                         PhasedSeries_H_SingleClass.class.getTypeName()));
 
     }
-
 }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
@@ -11,31 +11,17 @@
  */
 package com.adobe.campaign.tests.integro.phased;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.testng.Assert.assertThrows;
-
-import java.io.File;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.stream.Collectors;
-
+import com.adobe.campaign.tests.integro.phased.data.*;
+import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_RecipientClass.PhasedSeries_J_ShuffledClassInAClass;
+import com.adobe.campaign.tests.integro.phased.data.dp.PhasedSeries_L_ShuffledDP;
+import com.adobe.campaign.tests.integro.phased.data.dp.PhasedSeries_L_ShuffledDPSimple;
+import com.adobe.campaign.tests.integro.phased.data.dp.PhasedSeries_L_ShuffledNoArgs;
+import com.adobe.campaign.tests.integro.phased.data.dp.PhasedSeries_L_ShuffledWrongArgs;
+import com.adobe.campaign.tests.integro.phased.utils.GeneralTestUtils;
+import com.adobe.campaign.tests.integro.phased.utils.TestTools;
 import org.hamcrest.Matchers;
 import org.mockito.Mockito;
-import org.testng.ITestContext;
-import org.testng.ITestNGMethod;
-import org.testng.ITestResult;
-import org.testng.TestListenerAdapter;
-import org.testng.TestNG;
-import org.testng.TestNGException;
+import org.testng.*;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.internal.ConstructorOrMethod;
@@ -44,28 +30,14 @@ import org.testng.xml.XmlPackage;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
-import com.adobe.campaign.tests.integro.phased.data.NormalSeries_A;
-import com.adobe.campaign.tests.integro.phased.data.PhasedDataBrokerTestImplementation;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_A;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_B_NoInActive;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_C_NonAnnotatedDependencies;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_D_SingleNoPhase;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_E_FullMonty;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_F_Shuffle;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_G_DefaultProvider;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_H_ShuffledClass;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_H_ShuffledClassWithError;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_H_SingleClass;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_I_ShuffledProduceKey;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_I_SingleClassProduceTest;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_K_ShuffledClass_noproviders;
-import com.adobe.campaign.tests.integro.phased.data.PhasedSeries_RecipientClass.PhasedSeries_J_ShuffledClassInAClass;
-import com.adobe.campaign.tests.integro.phased.data.dp.PhasedSeries_L_ShuffledDP;
-import com.adobe.campaign.tests.integro.phased.data.dp.PhasedSeries_L_ShuffledDPSimple;
-import com.adobe.campaign.tests.integro.phased.data.dp.PhasedSeries_L_ShuffledNoArgs;
-import com.adobe.campaign.tests.integro.phased.data.dp.PhasedSeries_L_ShuffledWrongArgs;
-import com.adobe.campaign.tests.integro.phased.utils.GeneralTestUtils;
-import com.adobe.campaign.tests.integro.phased.utils.TestTools;
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.testng.Assert.assertThrows;
 
 public class TestPhased {
     @BeforeMethod
@@ -80,6 +52,8 @@ public class TestPhased {
         System.clearProperty(PhasedTestManager.PROP_MERGE_STEP_RESULTS);
 
         PhasedTestManager.deactivateMergedReports();
+        PhasedTestManager.deactivateTestSelectionByProducerMode();
+
         PhasedTestManager.MergedReportData.resetReport();
 
         //Delete temporary cache
@@ -142,12 +116,9 @@ public class TestPhased {
     }
 
     /**
-     * In this case if no shuffle is possible, and we have not set a Phase Event
-     * we should execute it as a normal test
-     *
+     * In this case if no shuffle is possible, and we have not set a Phase Event we should execute it as a normal test
+     * <p>
      * Author : gandomi
-     *
-     *
      */
     @Test
     public void testSINGLE_whereNoPhaseEventHasBeenSet() {
@@ -181,13 +152,10 @@ public class TestPhased {
     }
 
     /**
-     * In this case when we have not set any value regarding the Phase state we
-     * are in the state IANACTIVE. In this case the execution of not is defined
-     * by the Class Annotation
-     *
+     * In this case when we have not set any value regarding the Phase state we are in the state IANACTIVE. In this case
+     * the execution of not is defined by the Class Annotation
+     * <p>
      * Author : gandomi
-     *
-     *
      */
     @Test
     public void testProducer_ThatTheTestsOnlyExecuteUptoTheLimit_NoValueSet() {
@@ -228,12 +196,10 @@ public class TestPhased {
     }
 
     /**
-     * In this case when we have not set any value regarding the Phase state we
-     * are in the state IANACTIVE. In this case the execution of not is defined
-     * by the Class Annotation
-     *
+     * In this case when we have not set any value regarding the Phase state we are in the state IANACTIVE. In this case
+     * the execution of not is defined by the Class Annotation
+     * <p>
      * Author : gandomi
-     *
      */
     @Test
     public void testInActiveNoExecutions() {
@@ -312,12 +278,9 @@ public class TestPhased {
     }
 
     /**
-     * Related to issue #43 Skip consumer tests if the producer has not been
-     * executed.
-     *
+     * Related to issue #43 Skip consumer tests if the producer has not been executed.
+     * <p>
      * Author : gandomi
-     *
-     *
      */
     @Test
     public void testConsumerShuffled_noProducerHasRun() {
@@ -375,12 +338,9 @@ public class TestPhased {
     }
 
     /**
-     * Related to issue #43 Skip consumer tests if the producer has not been
-     * executed.
-     *
+     * Related to issue #43 Skip consumer tests if the producer has not been executed.
+     * <p>
      * Author : gandomi
-     *
-     *
      */
     @Test
     public void testConsumerSingle_noProducerHasRun() {
@@ -510,10 +470,8 @@ public class TestPhased {
 
     /**
      * Here we check that the consuming a producing is taken into account
-     *
+     * <p>
      * Author : gandomi
-     *
-     *
      */
     @Test
     public void testDataDependencyCheck() {
@@ -1459,12 +1417,9 @@ public class TestPhased {
     }
 
     /**
-     * in this example we check the precedence of the Runtime properties over
-     * the configuration files
-     *
+     * in this example we check the precedence of the Runtime properties over the configuration files
+     * <p>
      * Author : gandomi
-     *
-     *
      */
     @Test
     public void testProducer_SingleRun_DataBrokerSystemProperty() {
@@ -1511,12 +1466,9 @@ public class TestPhased {
     }
 
     /**
-     * in this example we check the precedence of the Runtime properties over
-     * the configuration files
-     *
+     * in this example we check the precedence of the Runtime properties over the configuration files
+     * <p>
      * Author : gandomi
-     *
-     *
      */
     @Test
     public void testProducer_SingleRun_DataBroker_Negative() {
@@ -2602,13 +2554,11 @@ public class TestPhased {
 
     /**
      * Testing the AppendShuffledGroupMethod
-     *
+     * <p>
      * Author : gandomi
-     * 
+     *
      * @throws SecurityException
      * @throws NoSuchMethodException
-     *
-     *
      */
     @SuppressWarnings("unchecked")
     @Test
@@ -2621,7 +2571,9 @@ public class TestPhased {
 
         //TODO replace, since this is invalid in later versions of Mockito
         //Mockito.when(l_itr.getMethod()).thenThrow(NoSuchFieldException.class);
-        Mockito.when(l_itr.getMethod()).thenAnswer(invocation -> { throw new NoSuchFieldException("Mocked Exception"); });
+        Mockito.when(l_itr.getMethod()).thenAnswer(invocation -> {
+            throw new NoSuchFieldException("Mocked Exception");
+        });
         Mockito.when(l_itr.getParameters()).thenReturn(new Object[] { "A" });
         Mockito.when(l_itrMethod.getConstructorOrMethod()).thenReturn(l_com);
         Mockito.when(l_com.getMethod()).thenReturn(l_myTestNoArgs);
@@ -2642,7 +2594,9 @@ public class TestPhased {
 
         //TODO replace, since this is invalid in later versions of Mockito
         //Mockito.when(l_itr.getMethod()).thenThrow(IllegalAccessException.class);
-        Mockito.when(l_itr.getMethod()).thenAnswer(invocation -> { throw new IllegalAccessException("Mocked Exception"); });
+        Mockito.when(l_itr.getMethod()).thenAnswer(invocation -> {
+            throw new IllegalAccessException("Mocked Exception");
+        });
         Mockito.when(l_itr.getParameters()).thenReturn(new Object[] { "A" });
         Mockito.when(l_itrMethod.getConstructorOrMethod()).thenReturn(l_com);
         Mockito.when(l_com.getMethod()).thenReturn(l_myTestNoArgs);
@@ -2946,19 +2900,10 @@ public class TestPhased {
 
     }
 
-    
-    
     /************** Testing issue #9 ******************/
-    
-    /**
-     * Starting from here we use he properties file as a test selector.
-     *
-     * Author : gandomi
-     *
-     *
-     */
+
     @Test
-    public void testConsumer_selectionBasedOnPopertiesFile() {
+    public void testConsumer_selectionBasedOnProducer_Deactivated() {
         // Rampup
         TestNG myTestNG = TestTools.createTestNG();
         TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
@@ -2974,19 +2919,164 @@ public class TestPhased {
 
         Phases.CONSUMER.activate();
         Properties phasedCache = PhasedTestManager.phasedCache;
-        phasedCache.put(PhasedSeries_H_SingleClass.class.getTypeName()+".step2("
+        phasedCache.put(PhasedSeries_H_SingleClass.class.getTypeName() + ".step2("
                 + PhasedTestManager.STD_PHASED_GROUP_SINGLE + ")", "AB");
 
-        PhasedTestManager.storeTestData(PhasedSeries_H_SingleClass.class,
-                PhasedTestManager.STD_PHASED_GROUP_SINGLE, "true");
+        PhasedTestManager
+                .storeTestData(PhasedSeries_H_SingleClass.class, PhasedTestManager.STD_PHASED_GROUP_SINGLE, "true");
+
+        assertThat("We should not be in the SELECT_BY_PRODUCER mode",
+                !PhasedTestManager.isTestsSelectedByProducerMode());
 
         myTestNG.run();
 
-        assertThat("We should have 1 successful methods of phased Tests",
+        assertThat("We should not be in the SELECT_BY_PRODUCER mode",
+                !PhasedTestManager.isTestsSelectedByProducerMode());
+
+        assertThat(
+                "Since we have not passed the test group PHASED_PRODUCED_TESTS, we should have no successful methods of phased Tests",
                 tla.getPassedTests().stream()
                         .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
-                        .collect(Collectors.toList()).size(),
-                is(equalTo(1)));
+                        .collect(Collectors.toList()).size(), is(equalTo(0)));
+    }
 
+    /**
+     * Starting from here we use he properties file as a test selector.
+     * <p>
+     * Author : gandomi
+     */
+    @Test
+    public void testConsumer_selectionBasedOnProducerFile() {
+        // Rampup
+        TestNG myTestNG = TestTools.createTestNG();
+        TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
+
+        // Define suites
+        XmlSuite mySuite = TestTools.addSuitToTestNGTest(myTestNG, "Automated Suite Phased Testing");
+
+        // Add listeners
+        mySuite.addListener(PhasedTestListener.class.getTypeName());
+
+        // Create an instance of XmlTest and assign a name for it.
+        XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Phased Tests");
+
+        //This activates the selection
+        myTest.addIncludedGroup(PhasedTestManager.STD_GROUP_SELECT_TESTS_BY_PRODUCER);
+
+        Phases.CONSUMER.activate();
+        Properties phasedCache = PhasedTestManager.phasedCache;
+        phasedCache.put(PhasedSeries_H_SingleClass.class.getTypeName() + ".step2("
+                + PhasedTestManager.STD_PHASED_GROUP_SINGLE + ")", "AB");
+
+        PhasedTestManager
+                .storeTestData(PhasedSeries_H_SingleClass.class, PhasedTestManager.STD_PHASED_GROUP_SINGLE, "true");
+
+        assertThat("We should not be in the SELECT_BY_PRODUCER mode",
+                !PhasedTestManager.isTestsSelectedByProducerMode());
+
+        myTestNG.run();
+
+        assertThat("We should be in the SELECT_BY_PRODUCER mode", PhasedTestManager.isTestsSelectedByProducerMode());
+
+        assertThat("The number of tests should not have changed",
+                tla.getTestContexts().get(0).getSuite().getXmlSuite().getTests().size(), equalTo(1));
+
+        assertThat("We should have 1 successful methods of phased Tests", tla.getPassedTests().stream()
+                .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
+                .collect(Collectors.toList()).size(), is(equalTo(1)));
+
+    }
+
+    /**
+     * In this test the same phased test is select by direct group selection and by selection through producer what we
+     * want is that this test should only be executed once
+     */
+    @Test
+    public void testSelectedByProducer_groupSelected() {
+        // Rampup
+        TestNG myTestNG = TestTools.createTestNG();
+        TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
+
+        // Define suites
+        XmlSuite mySuite = TestTools.addSuitToTestNGTest(myTestNG, "Automated Suite Phased Testing");
+
+        // Add listeners
+        mySuite.addListener(PhasedTestListener.class.getTypeName());
+
+        // Create an instance of XmlTest and assign a name for it.
+        XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
+
+        //Define packages
+        List<XmlPackage> l_packages = new ArrayList<>();
+        l_packages.add(new XmlPackage("com.adobe.campaign.tests.integro.phased.data"));
+        myTest.setXmlPackages(l_packages);
+
+        myTest.addIncludedGroup("PROPERTIES_SELECT");
+
+        Phases.CONSUMER.activate();
+
+        //Fill producer data
+        Properties phasedCache = PhasedTestManager.phasedCache;
+        phasedCache.put(PhasedSeries_H_SingleClass.class.getTypeName() + ".step2("
+                + PhasedTestManager.STD_PHASED_GROUP_SINGLE + ")", "AB");
+
+        PhasedTestManager
+                .storeTestData(PhasedSeries_H_SingleClass.class, PhasedTestManager.STD_PHASED_GROUP_SINGLE, "true");
+
+        myTestNG.run();
+
+        assertThat("We should have 1 successful methods of phased Tests", tla.getPassedTests().stream()
+                .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
+                .collect(Collectors.toList()).size(), is(equalTo(1)));
+    }
+
+    /**
+     * Testing how the feature of selection by properties works if we have many tests. In this example we have two
+     * tests. The first one executes a normal test. The second one has the execute by producer activated
+     */
+    @Test
+    public void testSelectByProperties_multiTest() {
+        // Rampup
+        TestNG myTestNG = TestTools.createTestNG();
+        TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
+
+        // Define suites
+        XmlSuite mySuite = TestTools.addSuitToTestNGTest(myTestNG, "Automated Suite Phased Testing");
+
+        // Add listeners
+        mySuite.addListener(PhasedTestListener.class.getTypeName());
+
+        // Test1 - include a simple test
+        XmlTest myTest1 = TestTools.attachTestToSuite(mySuite, "Two tests in suite #1. Normal test");
+
+        //Define packages
+        List<XmlPackage> l_packages = new ArrayList<>();
+        l_packages.add(new XmlPackage("com.adobe.campaign.tests.integro.phased.data"));
+        myTest1.setXmlPackages(l_packages);
+
+        myTest1.addIncludedGroup("PROPERTIES_TEST2");
+
+        //Test 2 - Include the phased test to be selected from producer
+
+        XmlTest myTest2 = TestTools.attachTestToSuite(mySuite, "Two tests in suite. Contains phased test.");
+
+        //This activates the selection for selection by Producerr
+        myTest2.addIncludedGroup(PhasedTestManager.STD_GROUP_SELECT_TESTS_BY_PRODUCER);
+
+        Phases.CONSUMER.activate();
+
+        //Fill producer data
+        Properties phasedCache = PhasedTestManager.phasedCache;
+        phasedCache.put(PhasedSeries_H_SingleClass.class.getTypeName() + ".step2("
+                + PhasedTestManager.STD_PHASED_GROUP_SINGLE + ")", "AB");
+
+        PhasedTestManager
+                .storeTestData(PhasedSeries_H_SingleClass.class, PhasedTestManager.STD_PHASED_GROUP_SINGLE, "true");
+
+        myTestNG.run();
+
+        assertThat("We should have 1 successful methods of phased Tests", tla.getPassedTests().stream()
+                .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
+                .collect(Collectors.toList()).size(), is(equalTo(1)));
     }
 }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
@@ -2959,7 +2959,7 @@ public class TestPhased {
      *
      *
      */
-    @Test
+    @Test(enabled = false)
     public void testConsumer_selectionBasedOnPopertiesFile() {
         // Rampup
         TestNG myTestNG = TestTools.createTestNG();

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
@@ -18,7 +18,6 @@ import static org.hamcrest.Matchers.not;
 import static org.testng.Assert.assertThrows;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2692,7 +2691,6 @@ public class TestPhased {
         assertThat("We should have no skipped tests", tla.getSkippedTests().size(), equalTo(0));
 
         /******** CONSUMER ********/
-
         Phases.CONSUMER.activate();
 
         TestNG myTestNG2 = TestTools.createTestNG();
@@ -2959,7 +2957,7 @@ public class TestPhased {
      *
      *
      */
-    @Test(enabled = false)
+    @Test
     public void testConsumer_selectionBasedOnPopertiesFile() {
         // Rampup
         TestNG myTestNG = TestTools.createTestNG();

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
@@ -1455,7 +1455,7 @@ public class TestPhased {
         //I.e. 2 step cache data + 1 scenario state
         //There is a comment line in the beginning
         assertThat("We should have three +1 lines",
-                GeneralTestUtils.fetchFileContentLines(l_storedFile).size(), Matchers.equalTo(4));
+                GeneralTestUtils.fetchFileContentDataLines(l_storedFile).size(), Matchers.equalTo(3));
 
     }
 
@@ -1507,7 +1507,7 @@ public class TestPhased {
         //I.e. 2 step cache data + 1 scenario state     
         //+ 1 line for the comment
         assertThat("We should have three +1  lines",
-                GeneralTestUtils.fetchFileContentLines(l_storedFile).size(), Matchers.equalTo(3 + 1));
+                GeneralTestUtils.fetchFileContentDataLines(l_storedFile).size(), Matchers.equalTo(2 + 1));
 
     }
 

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
@@ -102,15 +102,13 @@ public class TestPhased {
                 is(equalTo(0)));
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_A.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_A.class)).count(),
                 is(equalTo(2)));
 
         assertThat("We should have 1 successful methods of normal tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(NormalSeries_A.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(NormalSeries_A.class)).count(),
                 is(equalTo(1)));
 
     }
@@ -145,9 +143,8 @@ public class TestPhased {
                 is(equalTo(0)));
 
         assertThat("All Tests shuld have been executed",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_D_SingleNoPhase.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_D_SingleNoPhase.class)).count(),
                 is(equalTo(3)));
     }
 
@@ -182,15 +179,13 @@ public class TestPhased {
                 is(equalTo(0)));
 
         assertThat("We should have 3 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_A.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_A.class)).count(),
                 is(equalTo(3)));
 
         assertThat("We should have 1 successful methods of normal tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(NormalSeries_A.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(NormalSeries_A.class)).count(),
                 is(equalTo(1)));
 
     }
@@ -216,20 +211,18 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Phased Tests");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_B_NoInActive.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_B_NoInActive.class)));
 
         myTestNG.run();
 
         assertThat("We should have no executed methods of phased Tests",
-                tla.getFailedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_B_NoInActive.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getFailedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_B_NoInActive.class)).count(),
                 is(equalTo(0)));
 
         assertThat("We should have no executed methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_B_NoInActive.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_B_NoInActive.class)).count(),
                 is(equalTo(0)));
 
     }
@@ -264,15 +257,13 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 1 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class)).count(),
                 is(equalTo(1)));
 
         assertThat("We should have 1 successful methods of normal tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(NormalSeries_A.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(NormalSeries_A.class)).count(),
                 is(equalTo(1)));
 
     }
@@ -310,29 +301,25 @@ public class TestPhased {
 
         //This is because the Phase group 0-3 should still be executed
         assertThat("We should have 3 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_ShuffledClass.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_ShuffledClass.class)).count(),
                 is(equalTo(3)));
 
         //This is because the Phase groups 1-3 and 2-3 should not be executed
         assertThat("We should have no failed methods of phased Tests",
-                tla.getFailedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_ShuffledClass.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getFailedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_ShuffledClass.class)).count(),
                 is(equalTo(0)));
 
         //This is because phase groups 1-3 and 2-3 should not have the necessary context to run 
         assertThat("We should have 3 skipped methods of phased Tests",
-                tla.getSkippedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_ShuffledClass.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getSkippedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_ShuffledClass.class)).count(),
                 is(equalTo(3)));
 
         assertThat("We should have 1 successful methods of normal tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(NormalSeries_A.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(NormalSeries_A.class)).count(),
                 is(equalTo(1)));
 
     }
@@ -371,36 +358,32 @@ public class TestPhased {
 
         //This is because the Phase group 0-3 should still be executed
         assertThat("We should have 0 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(l_targetTestClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(l_targetTestClass)).count(),
                 is(equalTo(0)));
 
         //This is because the Phase groups 1-3 and 2-3 should not be executed
         assertThat("We should have no failed methods of phased Tests",
-                tla.getFailedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(l_targetTestClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getFailedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(l_targetTestClass)).count(),
                 is(equalTo(0)));
 
         //This is because phase groups 1-3 and 2-3 should not have the necessary context to run 
         assertThat("We should have 1 skipped methods of phased Tests",
-                tla.getSkippedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(l_targetTestClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getSkippedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(l_targetTestClass)).count(),
                 is(equalTo(1)));
 
         assertThat("We should have 1 successful methods of normal tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(NormalSeries_A.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(NormalSeries_A.class)).count(),
                 is(equalTo(1)));
 
     }
 
     @Test
     public void testFullMonty_SingleRun() {
-        /***** PRODUCER ****/
+        //  ***** PRODUCER ****
         TestNG myTestNG = TestTools.createTestNG();
         TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
 
@@ -413,27 +396,25 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Phased Tests");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_E_FullMonty.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_E_FullMonty.class)));
 
         Phases.PRODUCER.activate();
         myTestNG.run();
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class)).count(),
                 is(equalTo(2)));
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class)).count(),
                 is(equalTo(2)));
 
         assertThat("We should have no unsuccesful methods of phased Tests",
                 tla.getFailedTests().size() + tla.getSkippedTests().size(), is(equalTo(0)));
 
-        /***** COSNUMER ****/
+        // ***** COSNUMER ****
 
         //Clear data
         PhasedTestManager.clearCache();
@@ -451,14 +432,13 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest2 = TestTools.attachTestToSuite(mySuite2, "Test Phased Tests");
 
-        myTest2.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_E_FullMonty.class)));
+        myTest2.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_E_FullMonty.class)));
 
         myTestNG2.run();
 
         assertThat("We should have 1 successful methods of phased Tests",
-                tla2.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla2.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class)).count(),
                 is(equalTo(1)));
 
         assertThat("We should have no unsuccesful methods of phased Tests",
@@ -466,7 +446,7 @@ public class TestPhased {
 
     }
 
-    /***** Tests for DataDependencies ******/
+    // ***** Tests for DataDependencies ******
 
     /**
      * Here we check that the consuming a producing is taken into account
@@ -488,13 +468,13 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Phased Tests");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_C_NonAnnotatedDependencies.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_C_NonAnnotatedDependencies.class)));
 
         myTestNG.run();
 
-        assertThat("We should have no successful methods of phased Tests", tla.getPassedTests().stream()
-                .filter(m -> m.getInstance().getClass().equals(PhasedSeries_C_NonAnnotatedDependencies.class))
-                .collect(Collectors.toList()).size(), is(equalTo(3)));
+        assertThat("We should have no successful methods of phased Tests", (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_C_NonAnnotatedDependencies.class)).count(),
+                is(equalTo(3)));
 
         assertThat("We should have no successful methods of phased Tests",
                 tla.getFailedTests().size() + tla.getSkippedTests().size(), is(equalTo(0)));
@@ -519,7 +499,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests");
 
         final Class<PhasedSeries_F_Shuffle> l_testClass = PhasedSeries_F_Shuffle.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -529,8 +509,7 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
@@ -615,7 +594,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests");
 
         final Class<PhasedSeries_F_Shuffle> l_testClass = PhasedSeries_F_Shuffle.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -626,8 +605,7 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
@@ -716,7 +694,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Shuffled Phased Tests");
 
         final Class<PhasedSeries_F_Shuffle> l_testClass = PhasedSeries_F_Shuffle.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -743,8 +721,7 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
@@ -842,7 +819,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Shuffled Phased Tests");
 
         final Class<PhasedSeries_F_Shuffle> l_testClass = PhasedSeries_F_Shuffle.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -868,16 +845,12 @@ public class TestPhased {
         PhasedTestManager.storeTestData(PhasedSeries_F_Shuffle.class,
                 PhasedTestManager.STD_PHASED_GROUP_PREFIX + "1_2", "true");
 
-        Properties l_cache = PhasedTestManager.phasedCache;
-
-        Properties l_contex = PhasedTestManager.phaseContext;
         //Add the test context
 
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
@@ -981,7 +954,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_F_Shuffle> l_testClass = PhasedSeries_F_Shuffle.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -991,8 +964,7 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
@@ -1032,13 +1004,13 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest2 = TestTools.attachTestToSuite(mySuite2, "Test Repetetive Phased Tests Consumer");
 
-        myTest2.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest2.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         myTestNG2.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
+                        .count(),
                 is(equalTo(6)));
 
         //STEP 1
@@ -1130,7 +1102,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Merged Phased Tests Producer");
 
         final Class<PhasedSeries_F_Shuffle> l_testClass = PhasedSeries_F_Shuffle.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -1141,8 +1113,7 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
@@ -1179,13 +1150,13 @@ public class TestPhased {
         XmlTest myTest2 = TestTools.attachTestToSuite(mySuite2,
                 "Test Repetetive Phased Merged Tests Consumer");
 
-        myTest2.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest2.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         myTestNG2.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
+                        .count(),
                 is(equalTo(6)));
 
         //STEP 1
@@ -1275,14 +1246,13 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests");
 
         final Class<PhasedSeries_F_Shuffle> l_testClass = PhasedSeries_F_Shuffle.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(3)));
 
         //STEP 1
@@ -1319,7 +1289,7 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Simple Phased Tests");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_G_DefaultProvider.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_G_DefaultProvider.class)));
 
         Phases.PRODUCER.activate();
 
@@ -1329,9 +1299,8 @@ public class TestPhased {
                 is(equalTo(0)));
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_G_DefaultProvider.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_G_DefaultProvider.class)).count(),
                 is(equalTo(2)));
 
         assertThat("We should have executed step1 with the phased group 0",
@@ -1352,7 +1321,7 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Simple Phased Tests");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_G_DefaultProvider.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_G_DefaultProvider.class)));
 
         Phases.PRODUCER.activate();
 
@@ -1362,9 +1331,8 @@ public class TestPhased {
                 is(equalTo(0)));
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_G_DefaultProvider.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_G_DefaultProvider.class)).count(),
                 is(equalTo(3)));
 
         assertThat("We should have executed step1 with the phased default group ",
@@ -1392,16 +1360,15 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Simple Phased Tests");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_E_FullMonty.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_E_FullMonty.class)));
 
         Phases.PRODUCER.activate();
 
         myTestNG.run();
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class)).count(),
                 is(equalTo(2)));
 
         //Check that file was retreived
@@ -1439,7 +1406,7 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Simple Phased Tests");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_E_FullMonty.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_E_FullMonty.class)));
 
         Phases.PRODUCER.activate();
         System.setProperty(PhasedTestManager.PROP_PHASED_TEST_DATABROKER,
@@ -1448,9 +1415,8 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class)).count(),
                 is(equalTo(2)));
 
         //Check that file was retreived
@@ -1488,26 +1454,23 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Simple Phased Tests");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_E_FullMonty.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_E_FullMonty.class)));
 
-        assertThrows(TestNGException.class, () -> myTestNG.run());
+        assertThrows(TestNGException.class, myTestNG::run);
 
         assertThat("We should have no successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class)).count(),
                 is(equalTo(0)));
 
         assertThat("We should have no failed methods of phased Tests",
-                tla.getFailedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getFailedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class)).count(),
                 is(equalTo(0)));
 
         assertThat("We should have no skipped methods of phased Tests",
-                tla.getSkippedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getSkippedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_E_FullMonty.class)).count(),
                 is(equalTo(0)));
 
     }
@@ -1529,7 +1492,7 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Simple Phased Tests");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_H_SingleClass.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_H_SingleClass.class)));
 
         Phases.PRODUCER.activate();
 
@@ -1539,9 +1502,8 @@ public class TestPhased {
                 is(equalTo(0)));
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class)).count(),
                 is(equalTo(2)));
     }
 
@@ -1560,7 +1522,7 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Simple Phased Tests");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_H_SingleClass.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_H_SingleClass.class)));
 
         Phases.PRODUCER.activate();
         System.setProperty(PhasedTestManager.PROP_MERGE_STEP_RESULTS, "true");
@@ -1571,9 +1533,8 @@ public class TestPhased {
                 is(equalTo(0)));
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class)).count(),
                 is(equalTo(2)));
 
         ITestContext context = tla.getTestContexts().get(0);
@@ -1590,7 +1551,7 @@ public class TestPhased {
 
     @Test
     public void testSINGLE_ClassLevelFullMonty() {
-        /***** PRODUCER ****/
+        // ***** PRODUCER ****
         TestNG myTestNG = TestTools.createTestNG();
         TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
 
@@ -1605,25 +1566,23 @@ public class TestPhased {
 
         final Class<PhasedSeries_H_SingleClass> l_testClass = PhasedSeries_H_SingleClass.class;
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         Phases.PRODUCER.activate();
         myTestNG.run();
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(2)));
 
         assertThat("We should have 2 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(2)));
 
         assertThat("We should have no unsuccesful methods of phased Tests",
                 tla.getFailedTests().size() + tla.getSkippedTests().size(), is(equalTo(0)));
 
-        /***** COSNUMER ****/
+        // ***** COSNUMER ****
 
         //Clear data
         PhasedTestManager.clearCache();
@@ -1641,13 +1600,13 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest2 = TestTools.attachTestToSuite(mySuite2, "Test Phased Tests");
 
-        myTest2.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest2.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         myTestNG2.run();
 
         assertThat("We should have 1 successful methods of phased Tests",
-                tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
+                        .count(),
                 is(equalTo(1)));
 
         assertThat("We should have no unsuccesful methods of phased Tests",
@@ -1657,7 +1616,7 @@ public class TestPhased {
 
     @Test
     public void testSHUFFLED_ClassLevelFullMonty() {
-        /******** PRODUCER ********/
+        // ******** PRODUCER ********
         // Rampup
         TestNG myTestNG = TestTools.createTestNG();
         TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
@@ -1672,7 +1631,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_H_ShuffledClass> l_testClass = PhasedSeries_H_ShuffledClass.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -1681,15 +1640,14 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
         assertThat("We should have no failed tests", tla.getFailedTests().size(), equalTo(0));
         assertThat("We should have no skipped tests", tla.getSkippedTests().size(), equalTo(0));
 
-        /******** CONSUMER ********/
+        // ******** CONSUMER ********
 
         Phases.CONSUMER.activate();
 
@@ -1705,13 +1663,13 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest2 = TestTools.attachTestToSuite(mySuite2, "Test Repetetive Phased Tests Consumer");
 
-        myTest2.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest2.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         myTestNG2.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
+                        .count(),
                 is(equalTo(6)));
 
         //STEP 1
@@ -1774,7 +1732,7 @@ public class TestPhased {
 
     @Test(description = "Shuffling with an error")
     public void testSHUFFLED_ClassLevelFullMonty_Negative() {
-        /******** PRODUCER ********/
+        // ******** PRODUCER ********
         // Rampup
         TestNG myTestNG = TestTools.createTestNG();
         TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
@@ -1790,7 +1748,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_H_ShuffledClassWithError> l_testClass = PhasedSeries_H_ShuffledClassWithError.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -1838,7 +1796,7 @@ public class TestPhased {
                 tla.getSkippedTests().stream().filter(m -> m.getName().startsWith("step3")).anyMatch(
                         m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX + "3_0")));
 
-        /******** CONSUMER ********/
+        // ******** CONSUMER ********
 
         Phases.CONSUMER.activate();
 
@@ -1855,7 +1813,7 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest2 = TestTools.attachTestToSuite(mySuite2, "Test Repetetive Phased Tests Consumer");
 
-        myTest2.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest2.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         myTestNG2.run();
 
@@ -1939,7 +1897,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_H_ShuffledClassWithError> l_testClass = PhasedSeries_H_ShuffledClassWithError.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -2001,7 +1959,7 @@ public class TestPhased {
                 tla.getSkippedTests().stream().filter(m -> m.getName().startsWith("step3")).anyMatch(
                         m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX + "3_0")));
 
-        /******** CONSUMER ********/
+        // ******** CONSUMER ********
 
         Phases.CONSUMER.activate();
 
@@ -2018,7 +1976,7 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest2 = TestTools.attachTestToSuite(mySuite2, "Test Repetetive Phased Tests Consumer");
 
-        myTest2.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest2.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         myTestNG2.run();
 
@@ -2097,7 +2055,7 @@ public class TestPhased {
 
     @Test
     public void test_WithoutDataProvider() {
-        /******** PRODUCER ********/
+        // ******** PRODUCER ********
         // Rampup
         TestNG myTestNG = TestTools.createTestNG();
         TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
@@ -2112,7 +2070,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_K_ShuffledClass_noproviders> l_testClass = PhasedSeries_K_ShuffledClass_noproviders.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -2121,15 +2079,14 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
         assertThat("We should have no failed tests", tla.getFailedTests().size(), equalTo(0));
         assertThat("We should have no skipped tests", tla.getSkippedTests().size(), equalTo(0));
 
-        /******** CONSUMER ********/
+        // ******** CONSUMER ********
 
         Phases.CONSUMER.activate();
 
@@ -2145,13 +2102,13 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest2 = TestTools.attachTestToSuite(mySuite2, "Test Repetetive Phased Tests Consumer");
 
-        myTest2.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest2.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         myTestNG2.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
+                        .count(),
                 is(equalTo(6)));
 
         //STEP 1
@@ -2228,15 +2185,14 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_K_ShuffledClass_noproviders> l_testClass = PhasedSeries_K_ShuffledClass_noproviders.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
         myTestNG.run();
 
         assertThat("We should have 3 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(3)));
 
         //Global
@@ -2275,15 +2231,14 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_K_ShuffledClass_noproviders> l_testClass = PhasedSeries_K_ShuffledClass_noproviders.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
         myTestNG.run();
 
         assertThat("We should have 3 successful method of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(3)));
 
         //Global
@@ -2322,15 +2277,14 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_H_ShuffledClassWithError> l_testClass = PhasedSeries_H_ShuffledClassWithError.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
         myTestNG.run();
 
         assertThat("We should have 3 successful method of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(1)));
 
         //Global
@@ -2406,7 +2360,7 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Simple Phased Tests - produce");
 
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(PhasedSeries_I_SingleClassProduceTest.class)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(PhasedSeries_I_SingleClassProduceTest.class)));
 
         Phases.PRODUCER.activate();
 
@@ -2421,15 +2375,15 @@ public class TestPhased {
         assertThat("We should have no failed methods of phased Tests", tla.getFailedTests().size(),
                 is(equalTo(0)));
 
-        assertThat("We should have 1 successful method of phased Tests", tla.getPassedTests().stream()
-                .filter(m -> m.getInstance().getClass().equals(PhasedSeries_I_SingleClassProduceTest.class))
-                .collect(Collectors.toList()).size(), is(equalTo(1)));
+        assertThat("We should have 1 successful method of phased Tests", (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_I_SingleClassProduceTest.class)).count(),
+                is(equalTo(1)));
     }
 
     @Test
     public void testProducer_produceWithKeyCascaded() {
 
-        /******** PRODUCER ********/
+        // ******** PRODUCER ********
         // Rampup
         TestNG myTestNG = TestTools.createTestNG();
         TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
@@ -2446,7 +2400,7 @@ public class TestPhased {
                 "Test Repetetive Phased Tests Producer - Produce with Key");
 
         final Class<PhasedSeries_I_ShuffledProduceKey> l_testClass = PhasedSeries_I_ShuffledProduceKey.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -2455,112 +2409,22 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
         assertThat("We should have no failed tests", tla.getFailedTests().size(), equalTo(0));
         assertThat("We should have no skipped tests", tla.getSkippedTests().size(), equalTo(0));
 
-        /******** CONSUMER ********/
-        /*
-        //Clear data
-        PhasedTestManager.clearCache();
-        System.setProperty(PhasedTestManager.PROP_PHASED_TEST_STATE, PhasedTestState.CONSUMER.name());
-        
-        TestNG myTestNG2 = TestTools.createTestNG();
-        TestListenerAdapter tla2 = TestTools.fetchTestResultsHandler(myTestNG2);
-        
-        // Define suites
-        XmlSuite mySuite2 = TestTools.addSuitToTestNGTest(myTestNG2, "Automated Suite Phased Testing");
-        
-        // Add listeners
-        mySuite2.addListener("com.adobe.campaign.tests.integro.phased.PhasedTestListener");
-        
-        // Create an instance of XmlTest and assign a name for it.
-        XmlTest myTest2 = TestTools.attachTestToSuite(mySuite2, "Test Repetetive Phased Tests Consumer");
-        
-        myTest2.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
-        
-        myTestNG2.run();
-        
-        assertThat("We should have 6 successful methods of phased Tests",
-                tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
-                is(equalTo(6)));
-        
-        //STEP 1
-        assertThat("We should have no executions for the phased group 0",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step1"))
-                        .noneMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"0_3")));
-        
-        assertThat("We should NOT have executed step1 with the phased group 0",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step1"))
-                        .noneMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"1_3")));
-        
-        assertThat("We should NOT have executed step1 with the phased group 1",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step1"))
-                        .noneMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"2_3")));
-        
-        assertThat("We should have executed step1 with the phased group 2",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step1"))
-                        .anyMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"3_3")));
-        
-        //STEP 2
-        
-        assertThat("We should have no executions for the phased group 0",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step2"))
-                        .noneMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"0_3")));
-        
-        assertThat("We should NOT have executed step2 with the phased group 1",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step2"))
-                        .noneMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"1_3")));
-        
-        assertThat("We should have executed step2 with the phased group 2",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step2"))
-                        .anyMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"2_3")));
-        
-        assertThat("We should have executed step2 with the phased group 3",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step2"))
-                        .anyMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"3_3")));
-        
-        //STEP 3
-        assertThat("We should have no executions for the phased group 0",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step3"))
-                        .noneMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"0_3")));
-        
-        assertThat("We should have executed step3 with the phased group 1",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step3"))
-                        .anyMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"1_3")));
-        
-        assertThat("We should have executed step3 with the phased group 2",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step3"))
-                        .anyMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"2_3")));
-        
-        assertThat("We should have executed step3 with the phased group 3",
-                tla2.getPassedTests().stream().filter(m -> m.getName().equals("step3"))
-                        .anyMatch(m -> m.getParameters()[0].equals(PhasedTestManager.STD_PHASED_GROUP_PREFIX+"3_3")));
-        
-        //Global
-        assertThat("We should have no failed tests", tla2.getFailedTests().size(), equalTo(0));
-        assertThat("We should have no skipped tests", tla2.getSkippedTests().size(), equalTo(0));
-        
-        */
-
     }
 
-    /************** Test The listener **************/
+    /*   ************* Test The listener **************/
 
-    /**
+    /*
      * Testing the AppendShuffledGroupMethod
      * <p>
      * Author : gandomi
-     *
-     * @throws SecurityException
-     * @throws NoSuchMethodException
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testAppendShuffledGroupName() throws NoSuchMethodException, SecurityException {
         final Method l_myTestNoArgs = PhasedSeries_H_SingleClass.class.getMethod("step2", String.class);
@@ -2583,7 +2447,6 @@ public class TestPhased {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testAppendShuffledGroupName2() throws NoSuchMethodException, SecurityException {
         final Method l_myTestNoArgs = PhasedSeries_H_SingleClass.class.getMethod("step2", String.class);
@@ -2608,7 +2471,7 @@ public class TestPhased {
 
     @Test
     public void testSHUFFLED_ClassInAClass() {
-        /******** PRODUCER ********/
+        // ******** PRODUCER ********
         // Rampup
         TestNG myTestNG = TestTools.createTestNG();
         TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
@@ -2636,15 +2499,14 @@ public class TestPhased {
                 is(equalTo(12)));
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
         assertThat("We should have no failed tests", tla.getFailedTests().size(), equalTo(0));
         assertThat("We should have no skipped tests", tla.getSkippedTests().size(), equalTo(0));
 
-        /******** CONSUMER ********/
+        // ******** CONSUMER ********
         Phases.CONSUMER.activate();
 
         TestNG myTestNG2 = TestTools.createTestNG();
@@ -2659,13 +2521,13 @@ public class TestPhased {
         // Create an instance of XmlTest and assign a name for it.
         XmlTest myTest2 = TestTools.attachTestToSuite(mySuite2, "Test Repetetive Phased Tests Consumer");
 
-        myTest2.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest2.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         myTestNG2.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla2.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
+                        .count(),
                 is(equalTo(6)));
 
         //STEP 1
@@ -2743,7 +2605,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_L_ShuffledDP> l_testClass = PhasedSeries_L_ShuffledDP.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -2752,8 +2614,7 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
@@ -2777,7 +2638,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_L_ShuffledDPSimple> l_testClass = PhasedSeries_L_ShuffledDPSimple.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -2786,8 +2647,7 @@ public class TestPhased {
         myTestNG.run();
 
         assertThat("We should have 6 successful methods of phased Tests",
-                tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) tla.getPassedTests().stream().filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(6)));
 
         //Global
@@ -2811,7 +2671,7 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_L_ShuffledDPSimple> l_testClass = PhasedSeries_L_ShuffledDPSimple.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
@@ -2823,9 +2683,8 @@ public class TestPhased {
         ITestContext context = tla.getTestContexts().get(0);
 
         assertThat("We should have 6 successful methods of phased Tests",
-                context.getPassedTests().getAllResults().stream()
-                        .filter(m -> m.getInstance().getClass().equals(l_testClass))
-                        .collect(Collectors.toList()).size(),
+                (int) context.getPassedTests().getAllResults().stream()
+                        .filter(m -> m.getInstance().getClass().equals(l_testClass)).count(),
                 is(equalTo(4)));
 
         //Global
@@ -2864,13 +2723,13 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_L_ShuffledNoArgs> l_testClass = PhasedSeries_L_ShuffledNoArgs.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
         Phases.PRODUCER.activate();
 
-        assertThrows(PhasedTestConfigurationException.class, () -> myTestNG.run());
+        assertThrows(PhasedTestConfigurationException.class, myTestNG::run);
 
     }
 
@@ -2890,13 +2749,13 @@ public class TestPhased {
         XmlTest myTest = TestTools.attachTestToSuite(mySuite, "Test Repetetive Phased Tests Producer");
 
         final Class<PhasedSeries_L_ShuffledWrongArgs> l_testClass = PhasedSeries_L_ShuffledWrongArgs.class;
-        myTest.setXmlClasses(Arrays.asList(new XmlClass(l_testClass)));
+        myTest.setXmlClasses(Collections.singletonList(new XmlClass(l_testClass)));
 
         // Add package to test
 
         Phases.PRODUCER.activate();
 
-        assertThrows(PhasedTestConfigurationException.class, () -> myTestNG.run());
+        assertThrows(PhasedTestConfigurationException.class, myTestNG::run);
 
     }
 
@@ -2935,9 +2794,9 @@ public class TestPhased {
 
         assertThat(
                 "Since we have not passed the test group PHASED_PRODUCED_TESTS, we should have no successful methods of phased Tests",
-                tla.getPassedTests().stream()
-                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
-                        .collect(Collectors.toList()).size(), is(equalTo(0)));
+                (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class)).count(),
+                is(equalTo(0)));
     }
 
     /**
@@ -2981,9 +2840,9 @@ public class TestPhased {
         assertThat("The number of tests should not have changed",
                 tla.getTestContexts().get(0).getSuite().getXmlSuite().getTests().size(), equalTo(1));
 
-        assertThat("We should have 1 successful methods of phased Tests", tla.getPassedTests().stream()
-                .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
-                .collect(Collectors.toList()).size(), is(equalTo(1)));
+        assertThat("We should have 1 successful methods of phased Tests", (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class)).count(),
+                is(equalTo(1)));
 
     }
 
@@ -3025,9 +2884,9 @@ public class TestPhased {
 
         myTestNG.run();
 
-        assertThat("We should have 1 successful methods of phased Tests", tla.getPassedTests().stream()
-                .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
-                .collect(Collectors.toList()).size(), is(equalTo(1)));
+        assertThat("We should have 1 successful methods of phased Tests", (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class)).count(),
+                is(equalTo(1)));
     }
 
     /**
@@ -3075,8 +2934,10 @@ public class TestPhased {
 
         myTestNG.run();
 
-        assertThat("We should have 1 successful methods of phased Tests", tla.getPassedTests().stream()
-                .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
-                .collect(Collectors.toList()).size(), is(equalTo(1)));
+        assertThat("We should have a total of 2 successful methods", tla.getPassedTests().size(), is(equalTo(2)));
+
+        assertThat("We should have 1 successful methods of phased Tests", (int) tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class)).count(),
+                is(equalTo(1)));
     }
 }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhased.java
@@ -2948,4 +2948,47 @@ public class TestPhased {
 
     }
 
+    
+    
+    /************** Testing issue #9 ******************/
+    
+    /**
+     * Starting from here we use he properties file as a test selector.
+     *
+     * Author : gandomi
+     *
+     *
+     */
+    @Test
+    public void testConsumer_selectionBasedOnPopertiesFile() {
+        // Rampup
+        TestNG myTestNG = TestTools.createTestNG();
+        TestListenerAdapter tla = TestTools.fetchTestResultsHandler(myTestNG);
+
+        // Define suites
+        XmlSuite mySuite = TestTools.addSuitToTestNGTest(myTestNG, "Automated Suite Phased Testing");
+
+        // Add listeners
+        mySuite.addListener(PhasedTestListener.class.getTypeName());
+
+        // Create an instance of XmlTest and assign a name for it.
+        TestTools.attachTestToSuite(mySuite, "Test Phased Tests");
+
+        Phases.CONSUMER.activate();
+        Properties phasedCache = PhasedTestManager.phasedCache;
+        phasedCache.put(PhasedSeries_H_SingleClass.class.getTypeName()+".step2("
+                + PhasedTestManager.STD_PHASED_GROUP_SINGLE + ")", "AB");
+
+        PhasedTestManager.storeTestData(PhasedSeries_H_SingleClass.class,
+                PhasedTestManager.STD_PHASED_GROUP_SINGLE, "true");
+
+        myTestNG.run();
+
+        assertThat("We should have 1 successful methods of phased Tests",
+                tla.getPassedTests().stream()
+                        .filter(m -> m.getInstance().getClass().equals(PhasedSeries_H_SingleClass.class))
+                        .collect(Collectors.toList()).size(),
+                is(equalTo(1)));
+
+    }
 }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/data/NormalSeries_A.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/data/NormalSeries_A.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 
 public class NormalSeries_A {
     
-    @Test
+    @Test(groups="PROPERTIES_TEST2")
     public void firstTest() {
         
     }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/data/PhasedSeries_H_SingleClass.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/data/PhasedSeries_H_SingleClass.java
@@ -19,7 +19,7 @@ import com.adobe.campaign.tests.integro.phased.PhaseEvent;
 import com.adobe.campaign.tests.integro.phased.PhasedTest;
 import com.adobe.campaign.tests.integro.phased.PhasedTestManager;
 
-@Test(groups = { "UPGRADE" }, description = "This is an archetypical test for the phased tests")
+@Test(groups = { "UPGRADE", "PROPERTIES_SELECT" }, description = "This is an archetypical test for the phased tests")
 @PhasedTest(canShuffle = false)
 public class PhasedSeries_H_SingleClass {
 

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/utils/GeneralTestUtilsTests.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/utils/GeneralTestUtilsTests.java
@@ -149,6 +149,68 @@ public class GeneralTestUtilsTests {
     }
 
     @Test
+    public void testFetchingFileLines() {
+        File l_cacheDir = GeneralTestUtils.createCacheDirectory(TEST_CACHE_DIR);
+        File l_file = new File(l_cacheDir, TEST_CACHE_File);
+        
+        
+        //Create test data
+        Properties l_testProperties = new Properties();
+        l_testProperties.put("A", "B");
+        l_testProperties.put("C", "D");
+           
+        try (FileWriter fw = new FileWriter(l_file)) {
+
+            l_testProperties.store(fw, null);            
+
+        } catch (IOException e) {
+            throw new PhasedTestException("Error when creating file " + l_file + ".", e);
+        }
+
+        List<String> l_fileLines = GeneralTestUtils.fetchFileContentLines(l_file);
+        assertThat("We should have the correct number of tests", l_fileLines.size(),
+                Matchers.is(Matchers.equalTo(3)));
+
+    }
+
+    @Test
+    public void testFetchingFileLines_NonCommented() {
+        File l_cacheDir = GeneralTestUtils.createCacheDirectory(TEST_CACHE_DIR);
+        File l_file = new File(l_cacheDir, TEST_CACHE_File);
+        
+        
+        //Create test data
+        Properties l_testProperties = new Properties();
+        l_testProperties.put("A", "B");
+        l_testProperties.put("C", "D");
+           
+        try (FileWriter fw = new FileWriter(l_file)) {
+
+            l_testProperties.store(fw, null);            
+
+        } catch (IOException e) {
+            throw new PhasedTestException("Error when creating file " + l_file + ".", e);
+        }
+
+        assertThat("We should have the correct number of lines", GeneralTestUtils.fetchFileContentLines(l_file).size(),
+                Matchers.is(Matchers.equalTo(3)));
+        assertThat("We should have the correct number of tests", GeneralTestUtils.fetchFileContentDataLines(l_file).size(),
+                Matchers.is(Matchers.equalTo(2)));
+    }
+    
+    @Test
+    public void testFetchingFileDataLines_NegativeNonExistant() {
+        File l_cacheDir = GeneralTestUtils.createCacheDirectory(TEST_CACHE_DIR);
+        File l_file = new File(l_cacheDir, TEST_CACHE_File);
+
+        List<String> l_fileLines = GeneralTestUtils.fetchFileContentDataLines(l_file);
+        assertThat("We should have the correct number of tests", l_fileLines.size(),
+                Matchers.is(Matchers.equalTo(0)));
+
+    }
+    
+    
+    @Test
     public void testFetchingFileLines_NegativeNonExistant() {
         File l_cacheDir = GeneralTestUtils.createCacheDirectory(TEST_CACHE_DIR);
         File l_file = new File(l_cacheDir, TEST_CACHE_File);


### PR DESCRIPTION
## Description
In the context of  #9 we need to detect the tests to be run when we  are in the consumer mode. The usage is when we just want to run tests relevant to a version, and that are not present in a later one.

## Related Issue
* #9 
* #27 

- [ x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
