### PR TITLE
Issue75 better log at wrong annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,9 +375,11 @@ For now, we do not know how parallel execution will work with phased tests. So i
 For now, we have not come around to deciding how retry should work in the case of phased tests. By default, we deactivate them on the phased tests unless the user specifically chooses to activate them by setting the system property `PHASED.TESTS.RETRY.DISABLED` to false. 
 
 ## Release Notes
-### 7.0.10-SNAPSHOT when released
+### 7.0.10-SNAPSHOT
 - Reports are now merged by default (#56)
 - Refactoring : cleaning up cyclomatic complexity in the code (#49)
+- Fixed issue with the listener managing data providers for non-Phased tests.
+
 ### 7.0.9
 - Upgraded to TestNG 7.5
 - Resolved case of Skip due to config issues, such as a failure in a BeforePhase method (#41)

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
@@ -1153,10 +1153,11 @@ public final class PhasedTestManager {
     static Object[][] fetchDataProviderValues(Class<?> in_phasedTestClass) {
 
         final Object[][] lr_defaultReturnValue = new Object[0][0];
+
         if (!in_phasedTestClass.isAnnotationPresent(Test.class)) {
             log.warn(
-                    "{} The given phased test class does not have the Test annotation on it. Data Providers for Phased Tests can only be considered at that level.",
-                    PhasedTestManager.PHASED_TEST_LOG_PREFIX);
+                    "{} The given phased test class {} does not have the Test annotation on it. Data Providers for Phased Tests can only be considered at that level.",
+                    PhasedTestManager.PHASED_TEST_LOG_PREFIX, in_phasedTestClass.getTypeName());
 
             return lr_defaultReturnValue;
         }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/PhasedTestManagerTests.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/PhasedTestManagerTests.java
@@ -12,6 +12,7 @@
 package com.adobe.campaign.tests.integro.phased;
 
 import com.adobe.campaign.tests.integro.phased.data.*;
+import com.adobe.campaign.tests.integro.phased.data.befaft.PhasedSeries_M_SimpleClass;
 import com.adobe.campaign.tests.integro.phased.data.dp.*;
 import com.adobe.campaign.tests.integro.phased.utils.ClassPathParser;
 import com.adobe.campaign.tests.integro.phased.utils.GeneralTestUtils;
@@ -2512,6 +2513,15 @@ public class PhasedTestManagerTests {
                 equalTo(PhasedSeries_L_PROVIDER.PROVIDER_A));
         assertThat("We should have the correct values in the lines", result[1][0],
                 equalTo(PhasedSeries_L_PROVIDER.PROVIDER_B));
+    }
+
+    @Test
+    public void testFetchingDataProvidersInDPClass_NegativeNotPhasedTest() throws IllegalArgumentException {
+        Class<PhasedSeries_M_SimpleClass> l_classLevelDP = PhasedSeries_M_SimpleClass.class;
+
+        Object[][] result = PhasedTestManager.fetchDataProviderValues(l_classLevelDP);
+
+        assertThat("We should have no entries", result.length, equalTo(0));
     }
 
     @Test


### PR DESCRIPTION
The listener addresses data providers for non-phased tests. This caused unnecessary warnings.