### PR TITLE
Fixed #116 : Deprecated the canShuffle method. Allowing now for defin…

### DIFF
--- a/.github/workflows/maven-publish-deploy.yml
+++ b/.github/workflows/maven-publish-deploy.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: liberica
       # Set up dependency cache
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-publish-release.yml
+++ b/.github/workflows/maven-publish-release.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Set up dependency cache
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The diagram above represents what will be executed by the following code:
 
 ```java
 @Test
-@PhasedTest(canShuffle = false)
+@PhasedTest
 public class ShuffledTest {
 
     public void step1(String val) {
@@ -161,7 +161,7 @@ The code below will react differently depending on the PHASE/Execution mode it i
 
 ```java
 @Test
-@PhasedTest(canShuffle = true)
+@PhasedTest
 public class ShuffledTest {
 
     public void step1(String val) {
@@ -182,7 +182,7 @@ public class ShuffledTest {
 ```
 
 ##### Shuffled - Interruptive
-When a suffled test is executed in an interruptive mode (Phases PRODUCER and CONSUMER), we execute all the possible ordered combinations interruptions the scenario can be subject to. Example Given a test with three steps, in Producer State, we :
+When a shuffled test is executed in an interruptive mode (Phases PRODUCER and CONSUMER), we execute all the possible ordered combinations interruptions the scenario can be subject to. Example Given a test with three steps, in Producer State, we :
 1. Execute all the three steps
 2. Execute the first two steps
 3. Execute the first step only
@@ -217,19 +217,19 @@ Note : As of version 7.0.11, we now have the possibility to let the framework pi
 ### Setting Execution Modes
 
 #### Shuffled Mode
-In order for a test scenario to be executed in shuffle mode you need to add the following annotation at the class level `@PhasedTest(canShuffle = true)`
+In order for a test scenario to be executed in shuffle mode you need to add the following annotation at the class level `@PhasedTest`
 
 #### Single Run Mode
-In order for a test scenario to be executed in shuffle mode you need to add the following annotation at the class level `@PhasedTest(canShuffle = false)`. However because the interruption will happen at the same location all the time, you have to add the annotation `@PhaseEven@PhaseEvent` where you expect the interruption to occur.
+In order for a test scenario to be executed in shuffle mode you simply need to set the annotation `@PhaseEvent` somewhere along its steps.  The location of this annotation is where you expect the interruption to occur..
 
-Optionally if you consider that the scenario can never be run as non-phased, you need also include:  `@PhasedTest(canShuffle = false, executeInactive = false)`. When executeInactive is false, the Single Run scenario will only run when in Phases.
+Optionally if you consider that the scenario can never be run as non-phased, you need also include:  `@PhasedTest(executeInactive = false)`. When executeInactive is false, the Single Run scenario will only run when in Phases.
 
 ### Local Execution
 Ideally you should set the default data provider on your tests. This allows you to execute the test locally without needing to force the Phased Test listener.
 
 ```
 @Test( dataProvider = PhasedDataProvider.DEFAULT, dataProviderClass = PhasedDataProvider.class)
-@PhasedTest(canShuffle = true)
+@PhasedTest
 public class MyPhasedTest {
 }
 ```
@@ -286,7 +286,7 @@ In the case of single run scenarios, we can specify which phase event should be 
 
 In the example below the PhaseEvent is always executed at the step2 of the scenario. Here we have specified that when we are in asynchroous mode only the event `com.adobe.campaign.tests.integro.phased.data.events.MyNonInterruptiveEvent` should be executed. 
 ```Java
-@PhasedTest(canShuffle = false)
+@PhasedTest
 @Test
 public class SingleRunScenarioWithEvent {
 
@@ -312,7 +312,7 @@ public class SingleRunScenarioWithEvent {
 In this case we expect us to specify if a scenario is only subject to the same event. This will be done at the `@PhasedTest` annotation using the attribute `eventClasses`. When set we only use the specified event.
 
 ```Java
-@PhasedTest(canShuffle = true, eventClasses = {"com.adobe.campaign.tests.integro.phased.data.events.MyNonInterruptiveEvent"})
+@PhasedTest(eventClasses = {"com.adobe.campaign.tests.integro.phased.data.events.MyNonInterruptiveEvent"})
 @Test
 public class ShuffledScenarioWithEvent {
 
@@ -379,7 +379,7 @@ Example:
 ```java
 public class PhasedTestSeries_NestedContainer {
   @Test
-  @PhasedTest(canShuffle = true)
+  @PhasedTest
   public class PhasedScenario1 {
 
     public void step1(String val) {
@@ -394,7 +394,7 @@ public class PhasedTestSeries_NestedContainer {
   }
 
   @Test
-  @PhasedTest(canShuffle = true)
+  @PhasedTest
   public class PhasedScenario2 {
 
     public void step1(String val) {
@@ -575,6 +575,10 @@ For now, we have not come around to deciding how retry should work in the case o
 * [Implementation of execution order detection base on the code.](#Execution-Order) We now have two options:
   * We continue as before, where we select the order alphabetically.
   * Whenever the system property, PHASED.TESTS.DETECT.ORDER is set, the steps are executed in the order the way we declared in the code. By default, we expect the coe to be in maven where the tests are in the directory src/test/java. However, this can be overriden by setting the eecution property PHASED.TESTS.CODE.ROOT (#5)
+* [#116](https://github.com/adobe/phased-testing/issues/116) We are now removing the explicite "SingleRun" mode. 
+  * All Phased Tests without a @PhaseEvent anotation next to a step are now considered as "Shuffled".
+  * Any Phased Test with a @PhaseEvent annotation is a Singe Run test.
+  * We have now deprecated the @PhasedTest "canShuffle" attribute.
 
 ### 7.0.10
 - Reports are now merged by default (#56)

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,7 @@
                 <version>2.10.4</version>
                 <configuration>
                     <stylesheet>java</stylesheet>
+                    <source>8</source>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTest.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTest.java
@@ -10,15 +10,15 @@
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 /**
- * 
+ *
  */
 package com.adobe.campaign.tests.integro.phased;
-
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
@@ -31,6 +31,15 @@ import java.lang.annotation.Target;
 public @interface PhasedTest {
 
     boolean executeInactive() default true;
-    boolean canShuffle();
+
+    /**
+     * Lets us know if the phased test can shuffle
+     *
+     * @Deprecated From now on by default a phased test will shuffle, unless you set a @PaseEvent annotation on one of
+     * the steps. In that case the Phased test will be considered as a Single Run Phased test.
+     */
+    @Deprecated
+    boolean canShuffle() default true;
+
     String[] eventClasses() default {};
 }

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTest.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTest.java
@@ -35,7 +35,7 @@ public @interface PhasedTest {
     /**
      * Lets us know if the phased test can shuffle
      *
-     * @Deprecated From now on by default a phased test will shuffle, unless you set a @PaseEvent annotation on one of
+     * @deprecated From now on by default a phased test will shuffle, unless you set a @PaseEvent annotation on one of
      * the steps. In that case the Phased test will be considered as a Single Run Phased test.
      */
     @Deprecated

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
@@ -57,6 +57,7 @@ public final class PhasedTestManager {
 
     public static final String STD_MERGE_STEP_ERROR_PREFIX = "Phased Error: Failure in step ";
 
+
     /**
      * The different states a step can assume in a scenario
      * <p>
@@ -800,7 +801,7 @@ public final class PhasedTestManager {
      * @param in_testScenario A Phased Test
      * @return true if the scenario has a step that contains the annotation {{@link PhaseEvent}}
      */
-    public static boolean phasedTestHasEvent(Class in_testScenario) {
+    public static boolean isPhasedTestWithEvent(Class in_testScenario) {
 
         return Arrays.stream(in_testScenario.getDeclaredMethods()).anyMatch(t -> t.isAnnotationPresent(PhaseEvent.class));
     }
@@ -861,7 +862,9 @@ public final class PhasedTestManager {
      * @return True if the test class is a SingleRun Phase Test scenario
      */
     static boolean isPhasedTestSingleMode(Class<?> in_class) {
-        return isPhasedTest(in_class) && !in_class.getAnnotation(PhasedTest.class).canShuffle();
+        //TODO in 8.0.2 to be removed
+        //return isPhasedTest(in_class) && (isPhasedTestWithEvent(in_class)
+        return isPhasedTest(in_class) && (isPhasedTestWithEvent(in_class) || !in_class.getAnnotation(PhasedTest.class).canShuffle());
     }
 
     /**
@@ -894,9 +897,8 @@ public final class PhasedTestManager {
      * @return True if the given test scenario is a Shuffled Phased Test scenario
      */
     static boolean isPhasedTestShuffledMode(Class<?> in_class) {
-        return isPhasedTest(in_class) && in_class.getAnnotation(PhasedTest.class).canShuffle();
-        //return isPhasedTest(in_class) && in_class.getAnnotation(PhasedTest.class).canShuffle() && Phases
-        //        .getCurrentPhase().hasSplittingEvent() && !phasedTestHasEvent(in_class);
+        //return isPhasedTest(in_class) && in_class.getAnnotation(PhasedTest.class).canShuffle();
+        return isPhasedTest(in_class) && !isPhasedTestWithEvent(in_class) && in_class.getAnnotation(PhasedTest.class).canShuffle();
     }
 
     /**
@@ -1663,4 +1665,5 @@ public final class PhasedTestManager {
         }
         return lr_index;
     }
+
 }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/PhasedTestManagerTests.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/PhasedTestManagerTests.java
@@ -944,6 +944,20 @@ public class PhasedTestManagerTests {
 
         assertThat("step1 should be considered as a producer execution",
                 PhasedTestManager.isExecutedInProducerMode(l_myMethod));
+
+        final Method l_myMethodNew = PhasedTestSingleWithoutCanShuffle.class.getMethod("step1", String.class);
+
+        assertThat("step1 should be considered as a producer execution",
+                PhasedTestManager.isExecutedInProducerMode(l_myMethod));
+    }
+
+    @Test
+    public void testIsExecutedProducer_ConflictCanShuffleAndEvent() throws NoSuchMethodException, SecurityException {
+
+        final Method l_myMethod = PhasedSeries_H_ShuffledClass.class.getMethod("step1", String.class);
+
+        assertThat("step1 could not be be considered as a producer execution, as it has no event",
+                !PhasedTestManager.isExecutedInProducerMode(l_myMethod));
     }
 
     @Test
@@ -1146,28 +1160,27 @@ public class PhasedTestManagerTests {
      * Author : gandomi
      */
     @Test
-    public void testIsInCascadeMode() throws NoSuchMethodException, SecurityException {
-        final Method l_myMethod = PhasedSeries_F_Shuffle.class.getMethod("step3", String.class);
+    public void testIsInShuffledMode() throws NoSuchMethodException, SecurityException {
+        final Method l_myMethodTestOnMethods = PhasedSeries_F_Shuffle.class.getMethod("step3", String.class);
+        final Method l_myMethodTestOnClass = PhasedSeries_H_ShuffledClass.class.getMethod("step3", String.class);
+        final Method l_newShuffleRunFormat = PhasedTestShuffledWithoutCanShuffle.class.getMethod("step1", String.class);
+
+
+        assertThat("We should be in Shuffled mode", PhasedTestManager.isPhasedTestShuffledMode(l_myMethodTestOnMethods));
+        assertThat("We should be in Shuffled mode", PhasedTestManager.isPhasedTestShuffledMode(l_myMethodTestOnClass));
+        assertThat("We should be in Shuffled mode", PhasedTestManager.isPhasedTestShuffledMode(l_newShuffleRunFormat));
+
 
         Phases.CONSUMER.activate();
-        assertThat("We should be in Shuffled mode", PhasedTestManager.isPhasedTestShuffledMode(l_myMethod));
+        assertThat("We should be in Shuffled mode", PhasedTestManager.isPhasedTestShuffledMode(l_myMethodTestOnMethods));
+        assertThat("We should be in Shuffled mode", PhasedTestManager.isPhasedTestShuffledMode(l_myMethodTestOnClass));
+        assertThat("We should be in Shuffled mode", PhasedTestManager.isPhasedTestShuffledMode(l_newShuffleRunFormat));
+
     }
 
-    /**
-     * Testing issue #33 When we are in Inactive state the Shuffled should not happen
-     * <p>
-     * Author : gandomi
-     */
-    @Test
-    public void testIsInCascadeMode_Negative() throws NoSuchMethodException, SecurityException {
-        final Method l_myMethod = PhasedSeries_F_Shuffle.class.getMethod("step3", String.class);
-
-        assertThat("We should be in Shuffled mode",
-                PhasedTestManager.isPhasedTestShuffledMode(l_myMethod));
-    }
 
     @Test
-    public void testIsInCascadeMode_Negative2() throws NoSuchMethodException, SecurityException {
+    public void testIsInShuffleMode_Negative2() throws NoSuchMethodException, SecurityException {
         final Method l_myMethod = NormalSeries_A.class.getMethod("firstTest");
 
         Phases.CONSUMER.activate();
@@ -1177,12 +1190,25 @@ public class PhasedTestManagerTests {
     }
 
     @Test(description = "Testing with a single mode")
-    public void testIsInCascadeMode_Negative3() throws NoSuchMethodException, SecurityException {
+    public void testIsInShuffleMode_Negative3() throws NoSuchMethodException, SecurityException {
         final Method l_myMethod = PhasedSeries_A.class.getMethod("step1", String.class);
 
         Phases.CONSUMER.activate();
         assertThat("We should not be in Shuffled mode",
                 !PhasedTestManager.isPhasedTestShuffledMode(l_myMethod));
+
+        //Case 2
+        final Method l_myMethod2 = PhasedTestSingleWithoutCanShuffle.class.getMethod("step1", String.class);
+
+        assertThat("We should not be in Shuffled mode",
+                !PhasedTestManager.isPhasedTestShuffledMode(l_myMethod2));
+
+        //Case 3
+        final Method l_myMethod3 = PhasedSeries_D_SingleNoPhase.class.getMethod("step1", String.class);
+
+        assertThat("We should not be in Shuffled mode",
+                !PhasedTestManager.isPhasedTestShuffledMode(l_myMethod3));
+
     }
 
     //NIE
@@ -1190,33 +1216,48 @@ public class PhasedTestManagerTests {
     public void testHasAPhaseEvent() throws NoSuchMethodException {
 
         assertThat("We correctly identify that our class has an event",
-                PhasedTestManager.phasedTestHasEvent(TestSINGLEWithEvent_eventAsAnnotation.class));
+                PhasedTestManager.isPhasedTestWithEvent(TestSINGLEWithEvent_eventAsAnnotation.class));
     }
 
     @Test(description = "Testing in Aynchronous mode hello World" )
     public void testHasAPhaseEvent_Negative() throws NoSuchMethodException {
 
         assertThat("We correctly identify that our class does not have an event",
-                !PhasedTestManager.phasedTestHasEvent(PhasedSeries_H_ShuffledClass.class));
+                !PhasedTestManager.isPhasedTestWithEvent(PhasedSeries_H_ShuffledClass.class));
     }
 
 
     /****** Single mode tests *******/
 
+    //Issue #116 case 1
     @Test(description = "Testing with a single mode")
     public void testIsInSingleMode_STD() throws NoSuchMethodException, SecurityException {
-        final Method l_myMethod = PhasedSeries_A.class.getMethod("step1", String.class);
+        final Method l_myMethodTestOnMethods = PhasedSeries_A.class.getMethod("step1", String.class);
+
+        final Method l_myMethodTestOnClass = PhasedSeries_H_SingleClass.class.getMethod("step1", String.class);
+        final Method l_newSingleRunFormat = PhasedTestSingleWithoutCanShuffle.class.getMethod("step1", String.class);
+
+        assertThat("We should be in Single mode", PhasedTestManager.isPhasedTestSingleMode(l_myMethodTestOnMethods));
+        assertThat("We should be in Single mode", PhasedTestManager.isPhasedTestSingleMode(l_myMethodTestOnClass));
+        assertThat("We should be in Single mode", PhasedTestManager.isPhasedTestSingleMode(l_newSingleRunFormat));
 
         Phases.CONSUMER.activate();
-        assertThat("We should not be in Shuffled mode", PhasedTestManager.isPhasedTestSingleMode(l_myMethod));
+        assertThat("We should be in Single mode", PhasedTestManager.isPhasedTestSingleMode(l_myMethodTestOnMethods));
+        assertThat("We should be in Single mode", PhasedTestManager.isPhasedTestSingleMode(l_myMethodTestOnClass));
+        assertThat("We should be in Single mode", PhasedTestManager.isPhasedTestSingleMode(l_newSingleRunFormat));
     }
 
-    @Test(description = "Testing with a single mode")
-    public void testIsInSingleMode_InActiveState() throws NoSuchMethodException, SecurityException {
-        final Method l_myMethod = PhasedSeries_A.class.getMethod("step1", String.class);
+    @Test
+    public void testContradictionSingleWithNoEvent() throws NoSuchMethodException {
 
-        assertThat("We should not be in Shuffled mode", PhasedTestManager.isPhasedTestSingleMode(l_myMethod));
+        final Method l_newSingleRunFormat = PhasedSeries_D_SingleNoPhase.class.getMethod("step1", String.class);
+        assertThat("We should be in Single mode", PhasedTestManager.isPhasedTestSingleMode(l_newSingleRunFormat));
+
+        Phases.CONSUMER.activate();
+        assertThat("We should be in Single mode", PhasedTestManager.isPhasedTestSingleMode(l_newSingleRunFormat));
+
     }
+
 
     @Test
     public void testIsInSingleMode_Negative2() throws NoSuchMethodException, SecurityException {
@@ -1227,20 +1268,13 @@ public class PhasedTestManagerTests {
 
     }
 
+    //Issue #116 case 3
     @Test
     public void testIsInSingleMode_Shuffled_Negative3() throws NoSuchMethodException, SecurityException {
         final Method l_myMethod = PhasedSeries_H_ShuffledClass.class.getMethod("step1", String.class);
 
         Phases.PRODUCER.activate();
         assertThat("We should not be in single mode", !PhasedTestManager.isPhasedTestSingleMode(l_myMethod));
-
-    }
-
-    @Test
-    public void testIsInSingleMode() throws NoSuchMethodException, SecurityException {
-        final Method l_myMethod = PhasedSeries_F_Shuffle.class.getMethod("step3", String.class);
-
-        Phases.CONSUMER.activate();
         assertThat("We should be in Shuffled mode", PhasedTestManager.isPhasedTestShuffledMode(l_myMethod));
 
     }
@@ -3179,5 +3213,4 @@ public class PhasedTestManagerTests {
         assertThat(PhasedTestManager.MergedReportData.prefix,notNullValue());
         assertThat(PhasedTestManager.MergedReportData.suffix,notNullValue());
     }
-
 }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/data/PhasedTestShuffledWithoutCanShuffle.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/data/PhasedTestShuffledWithoutCanShuffle.java
@@ -11,37 +11,21 @@
  */
 package com.adobe.campaign.tests.integro.phased.data;
 
-import static org.testng.Assert.assertEquals;
-
+import com.adobe.campaign.tests.integro.phased.PhasedTest;
 import org.testng.annotations.Test;
 
-import com.adobe.campaign.tests.integro.phased.PhasedTest;
-import com.adobe.campaign.tests.integro.phased.PhasedTestManager;
-
-
-@PhasedTest(canShuffle = false)
-public class PhasedSeries_D_SingleNoPhase {
-    
-    @Test
-    public void step1(String val) {
-        System.out.println("step1 " + val);
-        PhasedTestManager.produceInStep("A");
-    }
-
-    @Test
-    public void step2(String val) {
-        System.out.println("step2 " + val);
-        String l_fetchedValue = PhasedTestManager.consumeFromStep("step1");
-        PhasedTestManager.produceInStep(l_fetchedValue + "B");
-    }
-
-    @Test
-    public void step3(String val) {
-        System.out.println("step3 " + val);
-        String l_fetchedValue = PhasedTestManager.consumeFromStep("step2");
-
-        assertEquals(l_fetchedValue, "AB");
+@PhasedTest
+@Test
+public class PhasedTestShuffledWithoutCanShuffle {
+    public void step1(String a) {
 
     }
 
+    public void step2(String a) {
+
+    }
+
+    public void step3(String a) {
+
+    }
 }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/data/PhasedTestShuffledWithoutCanShuffleNested.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/data/PhasedTestShuffledWithoutCanShuffleNested.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * © Copyright 2020 Adobe. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.adobe.campaign.tests.integro.phased.data;
+
+import com.adobe.campaign.tests.integro.phased.PhasedTest;
+import org.testng.annotations.Test;
+
+public class PhasedTestShuffledWithoutCanShuffleNested {
+    @PhasedTest
+    @Test
+    public class PhasedTestShuffledWithoutCanShuffleNestedInner {
+        public void step1(String a) {
+
+        }
+
+        public void step2(String a) {
+
+        }
+
+        public void step3(String a) {
+
+        }
+    }
+}

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/data/PhasedTestSingleWithCanShuffleTrue.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/data/PhasedTestSingleWithCanShuffleTrue.java
@@ -11,37 +11,23 @@
  */
 package com.adobe.campaign.tests.integro.phased.data;
 
-import static org.testng.Assert.assertEquals;
-
+import com.adobe.campaign.tests.integro.phased.PhaseEvent;
+import com.adobe.campaign.tests.integro.phased.PhasedTest;
 import org.testng.annotations.Test;
 
-import com.adobe.campaign.tests.integro.phased.PhasedTest;
-import com.adobe.campaign.tests.integro.phased.PhasedTestManager;
-
-
-@PhasedTest(canShuffle = false)
-public class PhasedSeries_D_SingleNoPhase {
-    
-    @Test
-    public void step1(String val) {
-        System.out.println("step1 " + val);
-        PhasedTestManager.produceInStep("A");
-    }
-
-    @Test
-    public void step2(String val) {
-        System.out.println("step2 " + val);
-        String l_fetchedValue = PhasedTestManager.consumeFromStep("step1");
-        PhasedTestManager.produceInStep(l_fetchedValue + "B");
-    }
-
-    @Test
-    public void step3(String val) {
-        System.out.println("step3 " + val);
-        String l_fetchedValue = PhasedTestManager.consumeFromStep("step2");
-
-        assertEquals(l_fetchedValue, "AB");
+@PhasedTest(canShuffle = true)
+@Test
+public class PhasedTestSingleWithCanShuffleTrue {
+    public void step1(String a) {
 
     }
 
+    @PhaseEvent
+    public void step2(String a) {
+
+    }
+
+    public void step3(String a) {
+
+    }
 }

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/data/PhasedTestSingleWithoutCanShuffle.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/data/PhasedTestSingleWithoutCanShuffle.java
@@ -11,37 +11,24 @@
  */
 package com.adobe.campaign.tests.integro.phased.data;
 
-import static org.testng.Assert.assertEquals;
-
+import com.adobe.campaign.tests.integro.phased.PhaseEvent;
+import com.adobe.campaign.tests.integro.phased.PhasedTest;
 import org.testng.annotations.Test;
 
-import com.adobe.campaign.tests.integro.phased.PhasedTest;
-import com.adobe.campaign.tests.integro.phased.PhasedTestManager;
-
-
-@PhasedTest(canShuffle = false)
-public class PhasedSeries_D_SingleNoPhase {
-    
-    @Test
-    public void step1(String val) {
-        System.out.println("step1 " + val);
-        PhasedTestManager.produceInStep("A");
-    }
-
-    @Test
-    public void step2(String val) {
-        System.out.println("step2 " + val);
-        String l_fetchedValue = PhasedTestManager.consumeFromStep("step1");
-        PhasedTestManager.produceInStep(l_fetchedValue + "B");
-    }
-
-    @Test
-    public void step3(String val) {
-        System.out.println("step3 " + val);
-        String l_fetchedValue = PhasedTestManager.consumeFromStep("step2");
-
-        assertEquals(l_fetchedValue, "AB");
+@PhasedTest
+@Test
+public class PhasedTestSingleWithoutCanShuffle {
+    public void step1(String a) {
 
     }
 
+
+    public void step2(String a) {
+
+    }
+
+    @PhaseEvent
+    public void step3(String a) {
+
+    }
 }


### PR DESCRIPTION
* [#116](https://github.com/adobe/phased-testing/issues/116) We are now removing the explicite "SingleRun" mode. 
  * All Phased Tests without a @PhaseEvent anotation next to a step are now considered as "Shuffled".
  * Any Phased Test with a @PhaseEvent annotation is a Singe Run test.
  * We have now deprecated the @PhasedTest "canShuffle" attribute.