### PR TITLE
Added the post step actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ Examples of events are:
     * [Local Execution](#local-execution)
     * [Non-Interruptive Events](#non-interruptive-events)
       * [Writing a Non-Interruptive Event](#writing-a-non-interruptive-event)
+        * [Performing Event Cleanup Actions](#performing-event-cleanup-actions)
       * [Binding an Event to a Scenario](#binding-an-event-to-a-scenario)
-      * [Attaching an Event using the PhaseEvent Annotation](#attaching-an-event-using-the-phaseevent-annotation)
-      * [Attaching an Event using the PhasedTest Annotation](#attaching-an-event-using-the-phasedtest-annotation)
-      * [Attaching an Event to the Test Suite](#attaching-an-event-to-the-test-suite)
-      * [Targeting an Event to a Specific Step](#targeting-an-event-to-a-specific-step)
+        * [Attaching an Event using the PhaseEvent Annotation](#attaching-an-event-using-the-phaseevent-annotation)
+        * [Attaching an Event using the PhasedTest Annotation](#attaching-an-event-using-the-phasedtest-annotation)
+        * [Attaching an Event to the Test Suite](#attaching-an-event-to-the-test-suite)
+        * [Targeting an Event to a Specific Step](#targeting-an-event-to-a-specific-step)
     * [Before- and After-Phase Actions](#before--and-after-phase-actions)
     * [Nested Design Pattern](#nested-design-pattern)
   * [Running a Phased Test](#running-a-phased-test)
@@ -297,7 +298,7 @@ As you can see we have to implement three methods:
 
 In order to define these event you will need to implement these methods, as you who are defining the event have the best knowledge on how these event will work.
 
-##### Performing Event Cleaner Actions
+##### Performing Event Cleanup Actions
 At times the simple execution of an event is not sufficient. We need to perform an event counter action to reset the system to a stable state. For this we allow you to define post step actions for an event. This means that after an event has been finished, we perform an additional set of actions before the next step is executed. To make use of this you need to override the method `runPostStepActions` in your event. The framework will then execute this action right before the next step is triggered.
 
 ```java
@@ -626,8 +627,8 @@ For now, we have not come around to deciding how retry should work in the case o
 ## Release Notes
 
 ### 8.11.2
-* [#178 Allowing the injection in any step of a scenario](https://github.com/adobe/bridgeService/issues/178). We can now inject an event into a step in an arbitrary phased test. This is done by setting the syetm property PHASED.EVENTS.TARGET. This way you can inject the event into that step.
-
+* **(new feature)** [#178 Allowing the injection in any step of a scenario](https://github.com/adobe/bridgeService/issues/178). We can now inject an event into a step in an arbitrary phased test. This is done by setting the syetm property PHASED.EVENTS.TARGET. This way you can inject the event into that step.
+* **(new feature)** [#198 Adding Post Step Event actions](https://github.com/adobe/bridgeService/issues/198). We allow you to define post-step actions in the context of an event. Please refer to the chapter [Performing Event Cleanup Actions](#performing-event-cleanup-actions).
 
 ### 8.11.1
 * Renaming ConfigValueHandler to ConfigValueHandlerPhased

--- a/README.md
+++ b/README.md
@@ -297,6 +297,17 @@ As you can see we have to implement three methods:
 
 In order to define these event you will need to implement these methods, as you who are defining the event have the best knowledge on how these event will work.
 
+##### Performing Event Cleaner Actions
+At times the simple execution of an event is not sufficient. We need to perform an event counter action to reset the system to a stable state. For this we allow you to define post step actions for an event. This means that after an event has been finished, we perform an additional set of actions before the next step is executed. To make use of this you need to override the method `runPostStepActions` in your event. The framework will then execute this action right before the next step is triggered.
+
+```java
+@Override
+public boolean runPostStepActions() {
+        // Perform actions
+        return true; //Return true if the actions were successful
+        }
+```
+
 #### Binding an Event to a Scenario
 In order for your scenario to interact with an event you will need to declare it. This can be done in three ways (in order of precedence) :
 * Phased Event Annotation
@@ -305,7 +316,7 @@ In order for your scenario to interact with an event you will need to declare it
 
 If you have the event declared in more than one level (for example on both the PhasedEvent and the PhasedTest annotation), it is the value with more precedence which is taken into account.
 
-#### Attaching an Event using the PhaseEvent Annotation
+##### Attaching an Event using the PhaseEvent Annotation
 The mode is only applicable to Single Run execution modes.
 
 In the case of single run scenarios, we can specify which phase event should be triggered on the annotation itself. This is by setting the `eventClasses` attribute for the `@PhaseEvent` annotation.
@@ -334,7 +345,7 @@ public class SingleRunScenarioWithEvent {
 }
 ```
 
-#### Attaching an Event using the PhasedTest Annotation
+##### Attaching an Event using the PhasedTest Annotation
 In this case we expect us to specify if a scenario is only subject to the same event. This will be done at the `@PhasedTest` annotation using the attribute `eventClasses`. When set we only use the specified event.
 
 ```Java
@@ -359,7 +370,7 @@ public class ShuffledScenarioWithEvent {
 }
 ```
 
-#### Attaching an Event to the Test Suite
+##### Attaching an Event to the Test Suite
 In this case, we state that all scenarios should be using the same Event. We can activate this mode by setting the environment variable `PHASED.EVENTS.NONINTERRUPTIVE` to the event class.
 
 This works for both Shuffled and Single-Run tests. If we want to run all tests with the event `com.adobe.campaign.tests.integro.phased.data.events.MyNonInterruptiveEvent`, we enter:
@@ -368,7 +379,7 @@ This works for both Shuffled and Single-Run tests. If we want to run all tests w
 
 You can also add it as a property in your testng definition file.
 
-#### Targeting an Event to a Specific Step
+##### Targeting an Event to a Specific Step
 As of version 8.11.2, we can inject an event to a specific step of a Phased Scenario. This is done by:
 * Declaring an event by setting the variable `PHASED.EVENTS.NONINTERRUPTIVE`.
 * Identifying the step on which an event will occur. This is done by setting the variable `PHASED.EVENTS.TARGET`.

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/NonInterruptiveEvent.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/NonInterruptiveEvent.java
@@ -59,4 +59,12 @@ public abstract class NonInterruptiveEvent implements Runnable {
         return state;
     }
 
+    /**
+     * Override this method to execute actions after the step subject to the event has been completed
+     * @return true if the post step actions were successful
+     */
+    public boolean runPostStepActions() {
+        return true;
+    }
+
 }

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedEventManager.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedEventManager.java
@@ -172,6 +172,7 @@ public class PhasedEventManager {
         l_activeEvent.waitTillFinished();
 
         logEvent(EventMode.END, in_event, in_onAccountOfStep);
+        l_activeEvent.runPostStepActions();
         return l_activeEvent;
     }
 

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhasedNonInterruptive.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/TestPhasedNonInterruptive.java
@@ -158,6 +158,43 @@ public class TestPhasedNonInterruptive {
         //PhasedEventManager.stopEventManager();
     }
 
+
+    @Test
+    public void eventManagerTests_conclusive() {
+        String myEvent = MyNonInterruptiveClosureEvent.class.getTypeName();
+
+        NonInterruptiveEvent nie = PhasedEventManager.startEvent(myEvent, "B");
+        Date start = new Date();
+        assertThat("Our event should be started", nie.getState().equals(NonInterruptiveEvent.states.STARTED));
+        assertThat("We should have stored an event object", PhasedEventManager.getEvents().size(), equalTo(1));
+        assertThat("We should have stored an event object", PhasedEventManager.getEvents().get("B"), notNullValue());
+        assertThat("We should have stored our event object", PhasedEventManager.getEvents().get("B"), equalTo(nie));
+
+
+        assertThat("There should be an event logged which is between the current and after dates",
+                PhasedEventManager.getEventLogs().size(), equalTo(1));
+
+
+        assertThat("The event should be currently on-going", !nie.isFinished());
+
+        //Stop event
+        NonInterruptiveEvent nieEND = PhasedEventManager.finishEvent(myEvent, "B");
+        assertThat("The event should no longer be on-going", nie, Matchers.equalTo(nieEND));
+        Date finish = new Date();
+
+        assertThat("The event should still be stopped now", nieEND.isFinished());
+
+        assertThat("The duration should be more than a second", (finish.getTime() - start.getTime()),
+                greaterThan(450l));
+        assertThat("The duration should be less than 2 seconds", (finish.getTime() - start.getTime()), lessThan(600l));
+        assertThat("Our event should be finished", nie.getState().equals(NonInterruptiveEvent.states.FINISHED));
+
+        assertThat("In the end executor should no longer be null (lazily instantiated)", PhasedEventManager.getEventExecutor(),notNullValue());
+        assertThat(((MyNonInterruptiveClosureEvent)nieEND).getTaskContainer(),equalTo(-2));
+
+        //PhasedEventManager.stopEventManager();
+    }
+
     @Test(description = "We start problematic instances")
     public void eventManagerTestsStart_negative() {
 

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/data/events/MyNonInterruptiveClosureEvent.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/data/events/MyNonInterruptiveClosureEvent.java
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * © Copyright 2020 Adobe. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.adobe.campaign.tests.integro.phased.data.events;
+
+import com.adobe.campaign.tests.integro.phased.NonInterruptiveEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class MyNonInterruptiveClosureEvent extends NonInterruptiveEvent {
+    public static final int WAIT_TIME_MS = 500;
+
+    private int taskContainer;
+    private static final Logger log = LogManager.getLogger();
+
+    public MyNonInterruptiveClosureEvent() {
+
+        taskContainer = 0;
+    }
+
+    @Override
+    public boolean startEvent() {
+        taskContainer = 1;
+        log.info("started");
+        return true;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return taskContainer < 0;
+    }
+
+    @Override
+    public boolean waitTillFinished() {
+
+        while (taskContainer != -1) {
+            try {
+                Thread.sleep(WAIT_TIME_MS);
+                taskContainer=-1;
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return isFinished();
+    }
+
+    @Override
+    public boolean runPostStepActions() {
+        taskContainer--;
+        return true;
+    }
+
+    public int getTaskContainer() {
+        return taskContainer;
+    }
+
+
+}

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/data/events/MyNonInterruptiveEvent.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/data/events/MyNonInterruptiveEvent.java
@@ -50,6 +50,7 @@ public class MyNonInterruptiveEvent extends NonInterruptiveEvent {
 
     @Override
     public boolean waitTillFinished() {
+        log.info("finishing");
 
         try {
             if (eventThread.isAlive()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

At times the simple execution of an event is not sufficient. We need to perform an event counter action to reset the system to a stable state. For this we allow you to define post step actions for an event. This means that after an event has been finished, we perform an additional set of actions before the next step is executed. To make use of this you need to override the method `runPostStepActions` in your event. The framework will then execute this action right before the next step is triggered.

```java
@Override
public boolean runPostStepActions() {
        // Perform actions
        return true; //Return true if the actions were successful
        }
```


## Related Issue

Fixes #198 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
