### PR TITLE
Decouple PhasedTestManager from MutationManager via a MutationMode SPI

### DIFF
--- a/src/main/java/com/adobe/campaign/tests/integro/phased/ExecutionMode.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/ExecutionMode.java
@@ -8,7 +8,7 @@
  */
 package com.adobe.campaign.tests.integro.phased;
 
-import com.adobe.campaign.tests.integro.phased.exceptions.MutationRampUpException;
+import com.adobe.campaign.tests.integro.phased.exceptions.ExecutionModeConfigurationException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -150,7 +150,7 @@ public enum ExecutionMode {
      */
     public void activate(String in_executionMode) {
         if (!behaviorTypes.contains(in_executionMode)) {
-            throw new MutationRampUpException("The given execution mode type is not valid for this execution type. Please use one of the following: " + behaviorTypes.toString());
+            throw new ExecutionModeConfigurationException("The given execution mode type is not valid for this execution type. Please use one of the following: " + behaviorTypes.toString());
         }
 
         ConfigValueHandlerPhased.PROP_EXECUTION_MODE.activate(this.name() + "(" + in_executionMode + ")");

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/MutationListener.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/MutationListener.java
@@ -126,13 +126,13 @@ public class MutationListener
             if (ExecutionMode.STANDARD.isSelected()) {
                 annotation.setDataProvider(
                         ConfigValueHandlerPhased.PHASED_TEST_NONPHASED_LEGACY.is("true") ? PhasedDataProvider.SINGLE : PhasedDataProvider.DEFAULT);
+                annotation.setDataProviderClass(PhasedDataProvider.class);
 
             } else {
                 annotation.setDataProvider(PhasedTestManager.isPhasedTestShuffledMode(
-                        l_currentClass) ? PhasedDataProvider.MUTATIONAL : PhasedDataProvider.MUTATIONAL_SINGLE);
+                        l_currentClass) ? MutationalDataProvider.MUTATIONAL : MutationalDataProvider.MUTATIONAL_SINGLE);
+                annotation.setDataProviderClass(MutationalDataProvider.class);
             }
-
-            annotation.setDataProviderClass(PhasedDataProvider.class);
         }
     }
 

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/MutationManager.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/MutationManager.java
@@ -8,16 +8,60 @@
  */
 package com.adobe.campaign.tests.integro.phased;
 
+import com.adobe.campaign.tests.integro.phased.spi.MutationMode;
 import com.adobe.campaign.tests.integro.phased.utils.ClassPathParser;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Collectors;
 
 public class MutationManager {
+
+    /**
+     * The {@link MutationMode} implementation for permutational ("Mutational") scenarios, delegating to this
+     * class's existing static methods. Discovered by {@link PhasedTestManager} via {@link java.util.ServiceLoader}
+     * (see {@code META-INF/services/com.adobe.campaign.tests.integro.phased.spi.MutationMode}) rather than through
+     * a compile-time reference, so it must be a public class with a public no-arg constructor.
+     */
+    public static final class MutationManagerMode implements MutationMode {
+
+        @Override
+        public boolean appliesTo(Method in_method) {
+            return isMutationalTest(in_method);
+        }
+
+        @Override
+        public boolean appliesTo(Class<?> in_class) {
+            return isMutationalTest(in_class);
+        }
+
+        @Override
+        public boolean appliesTo(ITestResult in_testResult) {
+            return isMutationalTest(in_testResult);
+        }
+
+        @Override
+        public boolean isSingleMode(Class<?> in_class) {
+            return MutationManager.isSingleMode(in_class);
+        }
+
+        @Override
+        public boolean isShuffleMode(Class<?> in_class) {
+            return MutationManager.isShuffleMode(in_class);
+        }
+
+        @Override
+        public String fetchScenarioName(ITestResult in_testResult) {
+            return MutationManager.fetchScenarioName(in_testResult);
+        }
+
+        @Override
+        public boolean ownsDataProviderClass(Class<?> in_dataProviderClass) {
+            return MutationalDataProvider.class.equals(in_dataProviderClass);
+        }
+    }
 
     /**
      * This method provides an ID for the scenario given the ITestNGResult. This is assembled using the Classname + the

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/Mutational.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/Mutational.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 @PhasedTest
-@Test(dataProvider = "MUTATIONAL", dataProviderClass = PhasedDataProvider.class)
+@Test(dataProvider = MutationalDataProvider.MUTATIONAL, dataProviderClass = MutationalDataProvider.class)
 public abstract class Mutational {
 
     public void scenario(String phaseGroup) throws Throwable {

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/MutationalDataProvider.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/MutationalDataProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+package com.adobe.campaign.tests.integro.phased;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.ITestNGMethod;
+import org.testng.annotations.DataProvider;
+
+public class MutationalDataProvider {
+    public static final String MUTATIONAL = "MUTATIONAL";
+    public static final String MUTATIONAL_SINGLE = "MUTATIONAL_SINGLE";
+
+    protected static Logger log = LogManager.getLogger();
+
+    @DataProvider(name = MUTATIONAL)
+    public Object[][] shuffleGroups(ITestNGMethod tm) {
+
+        log.info(tm.getTestClass().getRealClass().getTypeName());
+
+        return PhasedTestManager.fetchProvidersShuffled(tm);
+    }
+
+    @DataProvider(name = MUTATIONAL_SINGLE)
+    public Object[][] singleRunMode(ITestNGMethod tm) {
+        return MutationManager.fetchProvidersSingle(tm);
+    }
+}

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedDataProvider.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedDataProvider.java
@@ -10,43 +10,23 @@ package com.adobe.campaign.tests.integro.phased;
 
 import java.lang.reflect.Method;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.testng.ITestNGMethod;
 import org.testng.annotations.DataProvider;
 
 public class PhasedDataProvider {
     public static final String SHUFFLED = "phased-data-provider-shuffled";
     public static final String SINGLE = "phased-data-provider-single";
     public static final String DEFAULT = "phased-default";
-    public static final String MUTATIONAL = "MUTATIONAL";
-    public static final String MUTATIONAL_SINGLE = "MUTATIONAL_SINGLE";
-
 
     @DataProvider(name = SHUFFLED)
     public Object[][] shuffledMode(Method m) {
         return PhasedTestManager.fetchProvidersShuffled(m);
-    }
-    protected static Logger log = LogManager.getLogger();
-
-    @DataProvider(name = PhasedDataProvider.MUTATIONAL)
-    public Object[][] shuffleGroups(ITestNGMethod tm) {
-
-        log.info(tm.getTestClass().getRealClass().getTypeName());
-
-        return PhasedTestManager.fetchProvidersShuffled(tm);
-    }
-
-    @DataProvider(name = MUTATIONAL_SINGLE)
-    public Object[][] singleRunMode(ITestNGMethod tm) {
-        return MutationManager.fetchProvidersSingle(tm);
     }
 
     @DataProvider(name = SINGLE)
     public Object[] singleRunMode(Method m) {
         return PhasedTestManager.fetchProvidersSingle(m);
     }
-    
+
     @DataProvider(name = PhasedDataProvider.DEFAULT)
     public Object[] defaultDP(Method m) {
         return PhasedTestManager.fetchProvidersStandard(m);

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
@@ -893,30 +893,20 @@ public final class PhasedTestManager {
 
     /**
      * The registered {@link MutationMode} strategies, most-specific first. Additional modes (e.g.
-     * permutational) are discovered via {@link ServiceLoader}, so that this manager never references a
-     * concrete mode implementation by name, and discovery does not depend on some other class incidentally
-     * having been loaded first. Extra modes can also be registered programmatically via
-     * {@link #registerMutationMode(MutationMode)} (e.g. from tests). The built-in interruptive/shuffle mode
-     * (today's "Phased Testing") is always appended last: it is the generic, catch-all mode (its own steps
-     * carry no marker beyond the {@link PhasedTest} annotation, which can also incidentally be present on a
-     * more specific mode's own base class), so more specific modes must always get the first chance to claim
-     * a method/class/result.
+     * permutational) are discovered via {@link ServiceLoader} at class-load time, so that this manager never
+     * references a concrete mode implementation by name. Extra modes can also be registered programmatically
+     * via {@link #registerMutationMode(MutationMode)} (e.g. from tests). The built-in interruptive/shuffle
+     * mode (today's "Phased Testing") is always last: it is the generic, catch-all mode (its own steps carry
+     * no marker beyond the {@link PhasedTest} annotation, which can also incidentally be present on a more
+     * specific mode's own base class), so more specific modes must always get the first chance to claim a
+     * method/class/result.
      */
-    private static volatile List<MutationMode> mutationModes;
+    private static final List<MutationMode> mutationModes = buildMutationModes();
 
-    private static List<MutationMode> fetchMutationModes() {
-        List<MutationMode> l_modes = mutationModes;
-        if (l_modes == null) {
-            synchronized (PhasedTestManager.class) {
-                l_modes = mutationModes;
-                if (l_modes == null) {
-                    l_modes = new ArrayList<>();
-                    ServiceLoader.load(MutationMode.class).forEach(l_modes::add);
-                    l_modes.add(new PhasedShuffleMode());
-                    mutationModes = l_modes;
-                }
-            }
-        }
+    private static List<MutationMode> buildMutationModes() {
+        List<MutationMode> l_modes = new ArrayList<>();
+        ServiceLoader.load(MutationMode.class).forEach(l_modes::add);
+        l_modes.add(new PhasedShuffleMode());
         return l_modes;
     }
 
@@ -927,19 +917,17 @@ public final class PhasedTestManager {
      * @param in_mode the mutation mode to register
      */
     public static void registerMutationMode(MutationMode in_mode) {
-        fetchMutationModes().add(fetchMutationModes().size() - 1, in_mode);
+        mutationModes.add(mutationModes.size() - 1, in_mode);
     }
 
     private static MutationMode fetchApplicableMode(Class<?> in_class) {
-        List<MutationMode> l_modes = fetchMutationModes();
-        return l_modes.stream().filter(m -> m.appliesTo(in_class)).findFirst()
-                .orElseGet(() -> l_modes.get(l_modes.size() - 1));
+        return mutationModes.stream().filter(m -> m.appliesTo(in_class)).findFirst()
+                .orElseGet(() -> mutationModes.get(mutationModes.size() - 1));
     }
 
     private static MutationMode fetchApplicableMode(ITestResult in_testResult) {
-        List<MutationMode> l_modes = fetchMutationModes();
-        return l_modes.stream().filter(m -> m.appliesTo(in_testResult)).findFirst()
-                .orElseGet(() -> l_modes.get(l_modes.size() - 1));
+        return mutationModes.stream().filter(m -> m.appliesTo(in_testResult)).findFirst()
+                .orElseGet(() -> mutationModes.get(mutationModes.size() - 1));
     }
 
     /**
@@ -994,7 +982,7 @@ public final class PhasedTestManager {
      * @return true if The annotations PhasedTest and PhasedStep are present
      */
     public static boolean isPhasedTest(Method in_method) {
-        return fetchMutationModes().stream().anyMatch(m -> m.appliesTo(in_method));
+        return mutationModes.stream().anyMatch(m -> m.appliesTo(in_method));
     }
 
     /**
@@ -1006,7 +994,7 @@ public final class PhasedTestManager {
      * @return True if the class is a phased test scenario
      */
     public static boolean isPhasedTest(Class<?> in_class) {
-        return fetchMutationModes().stream().anyMatch(m -> m.appliesTo(in_class));
+        return mutationModes.stream().anyMatch(m -> m.appliesTo(in_class));
     }
 
     /**
@@ -1444,7 +1432,7 @@ public final class PhasedTestManager {
 
         final Class<?> l_candidateDataProviderClass = l_dataProviderClass;
         if (l_candidateDataProviderClass.equals(PhasedDataProvider.class)
-                || fetchMutationModes().stream().anyMatch(m -> m.ownsDataProviderClass(l_candidateDataProviderClass))) {
+                || mutationModes.stream().anyMatch(m -> m.ownsDataProviderClass(l_candidateDataProviderClass))) {
             return lr_defaultReturnValue;
         }
 

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/PhasedTestManager.java
@@ -12,6 +12,7 @@ import com.adobe.campaign.tests.integro.phased.exceptions.PhasedTestConfiguratio
 import com.adobe.campaign.tests.integro.phased.exceptions.PhasedTestException;
 import com.adobe.campaign.tests.integro.phased.permutational.ScenarioStepDependencies;
 import com.adobe.campaign.tests.integro.phased.permutational.StepDependencies;
+import com.adobe.campaign.tests.integro.phased.spi.MutationMode;
 import com.adobe.campaign.tests.integro.phased.utils.ClassPathParser;
 import com.adobe.campaign.tests.integro.phased.utils.GeneralTestUtils;
 import com.adobe.campaign.tests.integro.phased.utils.StackTraceManager;
@@ -891,6 +892,99 @@ public final class PhasedTestManager {
     }
 
     /**
+     * The registered {@link MutationMode} strategies, most-specific first. Additional modes (e.g.
+     * permutational) are discovered via {@link ServiceLoader}, so that this manager never references a
+     * concrete mode implementation by name, and discovery does not depend on some other class incidentally
+     * having been loaded first. Extra modes can also be registered programmatically via
+     * {@link #registerMutationMode(MutationMode)} (e.g. from tests). The built-in interruptive/shuffle mode
+     * (today's "Phased Testing") is always appended last: it is the generic, catch-all mode (its own steps
+     * carry no marker beyond the {@link PhasedTest} annotation, which can also incidentally be present on a
+     * more specific mode's own base class), so more specific modes must always get the first chance to claim
+     * a method/class/result.
+     */
+    private static volatile List<MutationMode> mutationModes;
+
+    private static List<MutationMode> fetchMutationModes() {
+        List<MutationMode> l_modes = mutationModes;
+        if (l_modes == null) {
+            synchronized (PhasedTestManager.class) {
+                l_modes = mutationModes;
+                if (l_modes == null) {
+                    l_modes = new ArrayList<>();
+                    ServiceLoader.load(MutationMode.class).forEach(l_modes::add);
+                    l_modes.add(new PhasedShuffleMode());
+                    mutationModes = l_modes;
+                }
+            }
+        }
+        return l_modes;
+    }
+
+    /**
+     * Registers an additional, more specific {@link MutationMode} strategy ahead of the built-in one, e.g.
+     * from a test, or from a module not discoverable via {@link ServiceLoader}.
+     *
+     * @param in_mode the mutation mode to register
+     */
+    public static void registerMutationMode(MutationMode in_mode) {
+        fetchMutationModes().add(fetchMutationModes().size() - 1, in_mode);
+    }
+
+    private static MutationMode fetchApplicableMode(Class<?> in_class) {
+        List<MutationMode> l_modes = fetchMutationModes();
+        return l_modes.stream().filter(m -> m.appliesTo(in_class)).findFirst()
+                .orElseGet(() -> l_modes.get(l_modes.size() - 1));
+    }
+
+    private static MutationMode fetchApplicableMode(ITestResult in_testResult) {
+        List<MutationMode> l_modes = fetchMutationModes();
+        return l_modes.stream().filter(m -> m.appliesTo(in_testResult)).findFirst()
+                .orElseGet(() -> l_modes.get(l_modes.size() - 1));
+    }
+
+    /**
+     * The built-in mutation mode implementing today's original Phased Testing behavior: interruptive events
+     * handled through shuffle groups and producer/consumer phases, declared via the {@link PhasedTest}
+     * annotation.
+     */
+    private static final class PhasedShuffleMode implements MutationMode {
+
+        @Override
+        public boolean appliesTo(Method in_method) {
+            return appliesTo(in_method.getDeclaringClass());
+        }
+
+        @Override
+        public boolean appliesTo(Class<?> in_class) {
+            return in_class.isAnnotationPresent(PhasedTest.class);
+        }
+
+        @Override
+        public boolean appliesTo(ITestResult in_testResult) {
+            return appliesTo(in_testResult.getMethod().getConstructorOrMethod().getMethod());
+        }
+
+        @Override
+        public boolean isSingleMode(Class<?> in_class) {
+            //TODO in 8.11.3 to be removed -  make public
+            //return isPhasedTest(in_class) && (isPhasedTestWithEvent(in_class)
+            return isPhasedTest(in_class) && (isPhasedTestWithEvent(in_class) || !in_class.getAnnotation(PhasedTest.class).canShuffle()) || isPhasedTestTargetOfEvent(in_class);
+        }
+
+        @Override
+        public boolean isShuffleMode(Class<?> in_class) {
+            return isPhasedTest(in_class) && !isPhasedTestWithEvent(in_class) && in_class.getAnnotation(PhasedTest.class)
+                    .canShuffle() && !isPhasedTestTargetOfEvent(in_class);
+        }
+
+        @Override
+        public String fetchScenarioName(ITestResult in_testResult) {
+            return in_testResult.getMethod().getConstructorOrMethod().getMethod().getDeclaringClass()
+                    .getTypeName() + ClassPathParser.fetchParameterValues(in_testResult);
+        }
+    }
+
+    /**
      * This method tells us if the method is a valid phased test. This is done by seeing if the annotation PhasedStep is
      * on the method, and if the annotation PhasedTest is on the class
      * <p>
@@ -900,7 +994,7 @@ public final class PhasedTestManager {
      * @return true if The annotations PhasedTest and PhasedStep are present
      */
     public static boolean isPhasedTest(Method in_method) {
-        return isPhasedTest(in_method.getDeclaringClass()) || MutationManager.isMutationalTest(in_method);
+        return fetchMutationModes().stream().anyMatch(m -> m.appliesTo(in_method));
     }
 
     /**
@@ -912,7 +1006,7 @@ public final class PhasedTestManager {
      * @return True if the class is a phased test scenario
      */
     public static boolean isPhasedTest(Class<?> in_class) {
-        return in_class.isAnnotationPresent(PhasedTest.class) || MutationManager.isMutationalTest(in_class);
+        return fetchMutationModes().stream().anyMatch(m -> m.appliesTo(in_class));
     }
 
     /**
@@ -932,13 +1026,7 @@ public final class PhasedTestManager {
      * @return True if the test class is a SingleRun Phase Test scenario
      */
     static boolean isPhasedTestSingleMode(Class<?> in_class) {
-        if (MutationManager.isMutationalTest(in_class)) {
-            return MutationManager.isSingleMode(in_class);
-        }
-
-        //TODO in 8.11.3 to be removed -  make public
-        //return isPhasedTest(in_class) && (isPhasedTestWithEvent(in_class)
-        return isPhasedTest(in_class) && (isPhasedTestWithEvent(in_class) || !in_class.getAnnotation(PhasedTest.class).canShuffle()) || isPhasedTestTargetOfEvent(in_class);
+        return fetchApplicableMode(in_class).isSingleMode(in_class);
     }
 
     /**
@@ -971,11 +1059,7 @@ public final class PhasedTestManager {
      * @return True if the given test scenario is a Shuffled Phased Test scenario
      */
     static boolean isPhasedTestShuffledMode(Class<?> in_class) {
-        if (MutationManager.isMutationalTest(in_class)) {
-            return MutationManager.isShuffleMode(in_class);
-        }
-        return isPhasedTest(in_class) && !isPhasedTestWithEvent(in_class) && in_class.getAnnotation(PhasedTest.class)
-                .canShuffle() && !isPhasedTestTargetOfEvent(in_class);
+        return fetchApplicableMode(in_class).isShuffleMode(in_class);
     }
 
     /**
@@ -988,11 +1072,7 @@ public final class PhasedTestManager {
      * @return The identity of the scenario
      */
     public static String fetchScenarioName(ITestResult in_testNGResult) {
-        if (MutationManager.isMutationalTest(in_testNGResult)) {
-            return MutationManager.fetchScenarioName(in_testNGResult);
-        }
-        return in_testNGResult.getMethod().getConstructorOrMethod().getMethod().getDeclaringClass()
-            .getTypeName() + ClassPathParser.fetchParameterValues(in_testNGResult);
+        return fetchApplicableMode(in_testNGResult).fetchScenarioName(in_testNGResult);
     }
 
     /**
@@ -1362,7 +1442,9 @@ public final class PhasedTestManager {
             return lr_defaultReturnValue;
         }
 
-        if (l_dataProviderClass.equals(PhasedDataProvider.class)) {
+        final Class<?> l_candidateDataProviderClass = l_dataProviderClass;
+        if (l_candidateDataProviderClass.equals(PhasedDataProvider.class)
+                || fetchMutationModes().stream().anyMatch(m -> m.ownsDataProviderClass(l_candidateDataProviderClass))) {
             return lr_defaultReturnValue;
         }
 

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/exceptions/ExecutionModeConfigurationException.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/exceptions/ExecutionModeConfigurationException.java
@@ -15,22 +15,19 @@ package com.adobe.campaign.tests.integro.phased.exceptions;
  * Author : gandomi
  *
  */
-public class MutationRampUpException extends RuntimeException {
+public class ExecutionModeConfigurationException extends RuntimeException {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -5305055623086270877L;
 
-    public MutationRampUpException(String in_msg, Throwable e) {
+    public ExecutionModeConfigurationException(String in_msg, Throwable e) {
         super(in_msg, e);
     }
 
-    public MutationRampUpException(String in_msg) {
+    public ExecutionModeConfigurationException(String in_msg) {
         super(in_msg);
     }
 
-    public MutationRampUpException() {
-        this("Unexpected Expection occurred when raping up the mutation tests.");
+    public ExecutionModeConfigurationException() {
+        this("Unexpected exception occurred when validating the execution mode configuration.");
     }
 }

--- a/src/main/java/com/adobe/campaign/tests/integro/phased/spi/MutationMode.java
+++ b/src/main/java/com/adobe/campaign/tests/integro/phased/spi/MutationMode.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+package com.adobe.campaign.tests.integro.phased.spi;
+
+import org.testng.ITestResult;
+
+import java.lang.reflect.Method;
+
+/**
+ * A pluggable strategy describing one of the possible ways a phased scenario's execution can mutate
+ * (e.g. interruptive-event shuffling, step permutation). {@link com.adobe.campaign.tests.integro.phased.PhasedTestManager}
+ * delegates to whichever registered mode applies to a given method/class/result, without knowing the
+ * concrete mode implementations itself.
+ */
+public interface MutationMode {
+
+    /**
+     * Tells us if the given method is governed by this mutation mode.
+     *
+     * @param in_method a candidate test method
+     * @return true if this mode applies to the given method
+     */
+    boolean appliesTo(Method in_method);
+
+    /**
+     * Tells us if the given class is governed by this mutation mode.
+     *
+     * @param in_class a candidate test class
+     * @return true if this mode applies to the given class
+     */
+    boolean appliesTo(Class<?> in_class);
+
+    /**
+     * Tells us if the given test result is governed by this mutation mode.
+     *
+     * @param in_testResult a TestNG test result
+     * @return true if this mode applies to the given test result
+     */
+    boolean appliesTo(ITestResult in_testResult);
+
+    /**
+     * Tells us if, under this mode, the given class is to be executed consequently in two phases.
+     *
+     * @param in_class a candidate test class
+     * @return true if the test class is a SingleRun scenario under this mode
+     */
+    boolean isSingleMode(Class<?> in_class);
+
+    /**
+     * Tells us if, under this mode, the given class is to be executed in a shuffled manner.
+     *
+     * @param in_class a candidate test class
+     * @return true if the test class is a Shuffled scenario under this mode
+     */
+    boolean isShuffleMode(Class<?> in_class);
+
+    /**
+     * Provides an ID for the scenario given the ITestResult, under this mode.
+     *
+     * @param in_testResult a TestNG test result
+     * @return the identity of the scenario
+     */
+    String fetchScenarioName(ITestResult in_testResult);
+
+    /**
+     * Tells us if the given class is one of this mode's own built-in TestNG {@code @DataProvider} classes
+     * (as opposed to a data provider class declared by the user of the framework). Built-in provider
+     * methods are invoked directly by the framework rather than reflectively by
+     * {@code PhasedTestManager.fetchDataProviderValues}, since their signatures are not a plain zero-arg
+     * user data provider.
+     *
+     * @param in_dataProviderClass a candidate data provider class
+     * @return true if this mode owns the given data provider class
+     */
+    default boolean ownsDataProviderClass(Class<?> in_dataProviderClass) {
+        return false;
+    }
+}

--- a/src/main/resources/META-INF/services/com.adobe.campaign.tests.integro.phased.spi.MutationMode
+++ b/src/main/resources/META-INF/services/com.adobe.campaign.tests.integro.phased.spi.MutationMode
@@ -1,0 +1,1 @@
+com.adobe.campaign.tests.integro.phased.MutationManager$MutationManagerMode

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/ExecutionModeTests.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/ExecutionModeTests.java
@@ -8,7 +8,7 @@
  */
 package com.adobe.campaign.tests.integro.phased;
 
-import com.adobe.campaign.tests.integro.phased.exceptions.MutationRampUpException;
+import com.adobe.campaign.tests.integro.phased.exceptions.ExecutionModeConfigurationException;
 import org.hamcrest.Matchers;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -70,7 +70,7 @@ public class ExecutionModeTests {
 
     @Test
     public void test_Negative_SetBadMode() {
-        Assert.assertThrows(MutationRampUpException.class, () -> ExecutionMode.INTERRUPTIVE.activate("23"));
+        Assert.assertThrows(ExecutionModeConfigurationException.class, () -> ExecutionMode.INTERRUPTIVE.activate("23"));
     }
 
     @Test

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/ExecutionModeTests.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/ExecutionModeTests.java
@@ -74,6 +74,22 @@ public class ExecutionModeTests {
     }
 
     @Test
+    public void testExecutionModeConfigurationException_DefaultMessage() {
+        assertThat("The default constructor should provide a default message",
+                new ExecutionModeConfigurationException().getMessage(), Matchers.notNullValue());
+    }
+
+    @Test
+    public void testExecutionModeConfigurationException_MessageAndCause() {
+        Throwable l_cause = new RuntimeException("root cause");
+        ExecutionModeConfigurationException l_exception = new ExecutionModeConfigurationException("my message",
+                l_cause);
+
+        assertThat("The message should be set", l_exception.getMessage(), Matchers.equalTo("my message"));
+        assertThat("The cause should be set", l_exception.getCause(), Matchers.equalTo(l_cause));
+    }
+
+    @Test
     public void testSetModeInterruptiveProducer() {
         ExecutionMode.INTERRUPTIVE.activate("PRODUCER");
 

--- a/src/test/java/com/adobe/campaign/tests/integro/phased/PhasedTestManagerTests.java
+++ b/src/test/java/com/adobe/campaign/tests/integro/phased/PhasedTestManagerTests.java
@@ -20,6 +20,7 @@ import com.adobe.campaign.tests.integro.phased.mutational.data.permutational.Mul
 import com.adobe.campaign.tests.integro.phased.mutational.data.permutational.ShoppingCartDemo;
 import com.adobe.campaign.tests.integro.phased.permutational.ScenarioStepDependencies;
 import com.adobe.campaign.tests.integro.phased.permutational.ScenarioStepDependencyFactory;
+import com.adobe.campaign.tests.integro.phased.spi.MutationMode;
 import com.adobe.campaign.tests.integro.phased.utils.ClassPathParser;
 import com.adobe.campaign.tests.integro.phased.utils.GeneralTestUtils;
 import com.adobe.campaign.tests.integro.phased.utils.MockTestTools;
@@ -1497,6 +1498,68 @@ public class PhasedTestManagerTests {
 
         assertThat("We should have the correct full name", PhasedTestManager.fetchScenarioName(l_itr),
                 equalTo("com.adobe.campaign.tests.integro.phased.data.PhasedSeries_H_ShuffledClassWithError(Q)"));
+    }
+
+    @Test
+    public void testFetchScenarioID_NonPhasedNonMutational_Fallback() throws NoSuchMethodException, SecurityException {
+        //A plain, non-phased, non-mutational method should fall back to the built-in mode's default naming
+        final Method l_myMethod = NormalSeries_A.class.getMethod("firstTest");
+
+        ITestResult l_itr = MockTestTools.generateTestResultMock(l_myMethod, new Object[0]);
+
+        assertThat("We should fall back to the declaring class' full name", PhasedTestManager.fetchScenarioName(l_itr),
+                equalTo("com.adobe.campaign.tests.integro.phased.data.NormalSeries_A"));
+    }
+
+    @Test
+    public void testRegisterMutationMode() throws NoSuchMethodException, SecurityException {
+        class RegisterMutationModeMarkerClass {
+            public void dummyStep() {
+            }
+        }
+
+        final Method l_dummyMethod = RegisterMutationModeMarkerClass.class.getMethod("dummyStep");
+
+        MutationMode l_customMode = new MutationMode() {
+            @Override
+            public boolean appliesTo(Method in_method) {
+                return in_method.getDeclaringClass().equals(RegisterMutationModeMarkerClass.class);
+            }
+
+            @Override
+            public boolean appliesTo(Class<?> in_class) {
+                return in_class.equals(RegisterMutationModeMarkerClass.class);
+            }
+
+            @Override
+            public boolean appliesTo(ITestResult in_testResult) {
+                return false;
+            }
+
+            @Override
+            public boolean isSingleMode(Class<?> in_class) {
+                return true;
+            }
+
+            @Override
+            public boolean isShuffleMode(Class<?> in_class) {
+                return false;
+            }
+
+            @Override
+            public String fetchScenarioName(ITestResult in_testResult) {
+                return "custom-scenario-name";
+            }
+        };
+
+        PhasedTestManager.registerMutationMode(l_customMode);
+
+        assertThat("The newly registered mode should recognize the marker class as a phased test",
+                PhasedTestManager.isPhasedTest(l_dummyMethod));
+        assertThat("The newly registered mode should recognize the marker class as a phased test",
+                PhasedTestManager.isPhasedTest(RegisterMutationModeMarkerClass.class));
+        assertThat("The newly registered mode should classify the marker class as single mode",
+                PhasedTestManager.isPhasedTestSingleMode(l_dummyMethod));
     }
 
     /**


### PR DESCRIPTION
## Summary
- Groundwork for #224: introduces a `MutationMode` SPI (discovered via `ServiceLoader`) so `PhasedTestManager` no longer has any compile-time reference to `MutationManager`/`MutationListener`/`Mutational`. The legacy interruptive/shuffle logic becomes the built-in `PhasedShuffleMode`; the permutational logic self-registers from `MutationManager`.
- Splits `PhasedDataProvider` into `PhasedDataProvider` (core: `SHUFFLED`/`SINGLE`/`DEFAULT`) and a new `MutationalDataProvider` (`MUTATIONAL`/`MUTATIONAL_SINGLE`), extending the SPI with `ownsDataProviderClass(...)` so core's reflective data-provider handling still recognizes framework-owned providers without naming them.
- Renames `MutationRampUpException` → `ExecutionModeConfigurationException` (breaking change for anyone catching it by name) since it's a generic execution-mode validation error unrelated to mutational testing.

No Maven multi-module split yet, no public package/class renames beyond the exception rename — this only removes the internal coupling so a future module split (or further generalization per the "Mutating Test Scenarios" paper's Data/Events/Permutations taxonomy) is easier later.

## Test plan
- [x] `mvn test` — all 434 tests pass
- [x] `grep -n MutationManager PhasedTestManager.java` returns no matches outside this PR's own SPI wiring
- [x] Verified via debug run that `ServiceLoader` correctly discovers `MutationManager$MutationManagerMode` and that specific modes are tried before the generic fallback mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)