### PR TITLE
Reorganize docs for the multi-module split (issue #224 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+## 10.0.0
+* **(breaking change)** [#224 Split the project into a multi-module project](https://github.com/adobe/phased-testing/issues/224). The project is now a multi-module Maven build: `phased-testing-core` (shared engine), `phased-testing-testng` (annotation-driven authoring, same artifact coordinates as before), and `phased-testing-mutational` (new artifact, inheritance/template-method authoring). If you only use the classic `@PhasedTest` annotation model, no changes are required beyond bumping the version. If you use `Mutational`/`MutationListener`, you now need to add a dependency on `phased-testing-mutational` explicitly — see [Installation](README.md#installation).
+* **(breaking change)** The internal package `com.adobe.campaign.tests.integro.phased.permutational` has been renamed to `com.adobe.campaign.tests.integro.phased.stepdependencies`. This only affects code that directly imports classes from that package (`ScenarioStepDependencies`, `ScenarioStepDependencyFactory`, `StepDependencies`), not typical library usage.
+* **(breaking change)** The exception `MutationRampUpException` has been renamed to `ExecutionModeConfigurationException`, since it is thrown for a generic invalid-execution-mode configuration error, unrelated to Mutational Testing specifically.
+
+## 9.0.0 - In-Progress
+* **(new feature)** [#204 Introduction of the Execution Mode replacing Phases](https://github.com/adobe/phased-testing/issues/204). We have revised the way we execute scenarios, as we no longer only cater to Upgrade tests. The means you should revise the way you execute Phased Tests by using Execution Modes. For more information please refer to the chapter [Execution Modes](README.md#execution-modes).
+* **(new feature)** [#35 Adding the Permutation Execution Mode](https://github.com/adobe/phased-testing/issues/35). We have introduced the Permutation Execution Mode. This mode executes a scenario with all possible permutations it can have. This is done by identifying the dependencies between each step, and creating the possible orders of that scenario. For more information please refer to the chapters [Permutation Execution Mode](README.md#permutation-execution-mode).
+* **(new feature)** [#197 Adding the event wrappings to a step](https://github.com/adobe/phased-testing/issues/197). We have now introduced the different wrappings an event can have around a test step. Wrappings can be set in different ways: Execution Mode, Event annotation (in progress), The Phased Test Annotation.
+
+* **New Environment Variables**
+* MUTATIONAL.EXECUTION.MODE : This property is used to set the execution mode of the Mutational Tests. The value can be one of the following: STANDARD, INTERRUPTIVE(PRODUCER), INTERRUPTIVE(CONSUMER), NON-INTERRUPTIVE, PERMUATIONAL. This will replace the PHASED.TESTS.PHASE property which will be removed in 9.X.3.
+* MUTATIONAL.EVENTS.TARGET : This property allows us to run a single event on a specific step of a scenario. The notation is either the standard method reference, or that of Surefire.
+
+## 8.11.2
+* **(new feature)** [#178 Allowing the injection in any step of a scenario](https://github.com/adobe/phased-testing/issues/178). We can now inject an event into a step in an arbitrary phased test. This is done by setting the syetm property PHASED.EVENTS.TARGET. This way you can inject the event into that step.
+* **(new feature)** [#198 Adding Post Step Event actions](https://github.com/adobe/phased-testing/issues/198). We allow you to define a 'tearDownEvent' tool to allow you to put the system back to a normal state after the event has finished. Please refer to the chapter [Performing Event Cleanup Actions](README.md#performing-event-cleanup-actions).
+
+## 8.11.1
+* Renaming ConfigValueHandler to ConfigValueHandlerPhased
+* Migrating to Java 11
+* Upgrading the TestNG library to 7.8.0
+
+## 8.0.0
+* [Non-Interrupted Events](README.md#shuffled---non-interruptive)
+* [#112](https://github.com/adobe/phased-testing/issues/112) Technical : Extracted the execution properties to the class ConfigValueHandler.
+* [#115](https://github.com/adobe/phased-testing/issues/115) Fixed bug where the Non-Phased execution was stored as SINGLE-RUN. You can still keep the old behaviour by passing the property "PHASED.TESTS.NONPHASED.LEGACY" to "true". However by default they are stored as "phased-default".
+* [#114](https://github.com/adobe/phased-testing/issues/114) Technical : The methods PhasedTestManager.isPhasedTestShuffledMode & PhasedTestManager.isPhasedTestSingleMode no longer take into account the current phase. Instead, they simply return the information about wether or not the given method/class is Shuffled or Single Mode.
+* [Implementation of execution order detection base on the code.](README.md#execution-order) We now have two options:
+  * We continue as before, where we select the order alphabetically.
+  * Whenever the system property, PHASED.TESTS.DETECT.ORDER is set, the steps are executed in the order the way we declared in the code. By default, we expect the coe to be in maven where the tests are in the directory src/test/java. However, this can be overriden by setting the eecution property PHASED.TESTS.CODE.ROOT (#5)
+* [#116](https://github.com/adobe/phased-testing/issues/116) We are now removing the explicite "SingleRun" mode.
+  * All Phased Tests without a @PhaseEvent annotation next to a step are now considered as "Shuffled".
+  * Any Phased Test with a @PhaseEvent annotation is a Singe Run test.
+  * We have now deprecated the @PhasedTest "canShuffle" attribute.
+
+## 7.0.10
+- Reports are now merged by default (#56)
+- Refactoring : cleaning up cyclomatic complexity in the code (#49).
+- Fixed issue with the listener managing data providers for non-Phased tests (#75).
+
+## 7.0.9
+- Upgraded to TestNG 7.5
+- Resolved case of Skip due to config issues, such as a failure in a BeforePhase method (#41)
+- We no longer throw SkipExceptions in the OnStartTest. Instead, we set the status to Skipped (#42)
+- Consumer results can now contain the results of the PRODUCER phase (#34)
+- Storing duration and the phase in the scenario state (#36)
+- Updated Log4J to 2.17.1 to resolve security issues (#38)
+- Implemented the new select tests to run based on the producer phase (#9)
+- Solved case when the users really wants to use retry. In this case we do not interrupt the retry mechanism.
+- Moved back to java 8. We now compile the artefacts in java 8. This is because our main users are not yet in higher java versions.
+- Removed the deprecated methods `PhasedTestManager.produceWithKey` and `PhasedTestManager.consumeWithKey`.
+
+## 7.0.8
+- Upgraded java version to Java 11
+- Activated sonar scans
+- Solved Sonar highlighted bugs #20, #21, #23, #24
+- Fixed issue #28 where the skip message when no steps have been executed previously for the current scenario phase group happens
+
+## 7.0.7
+- Migrated to the public git repository.
+
+## 7.0.5
+- You can now define Phase setup methods. `@BeforePhase` & `@AfterPhase` can be set on a normal TestNG Before and After method. The method will then be executed in before or after a phase starts. (#40)
+- We now allow for user defined data providers in a phased test. For the data provider to be considered, it needs to be declared at class level and not at method level. (#26)
+- We can now configure the reports to include the data providers.
+- We now throw an error if the arguments of the phased steps do not correspond to expected number of parameters (phased + user defined) (#28 & #27 & #38)
+- Solved issue with tests continuing in consumer mode even if their steps had not been executed in the producer phase
+
+## 7.0.4
+- Introduced the Report by Phase Group Functionality (#5)
+- Allowing users to configure the Merged Reports
+- Other issues corrected are : #20, #22, #23, #24, #25
+
+## 7.0.3
+- Renamed old produce/consume to produceInStep/consumeFromStep. The old produceWithKey/consumeWith key are now deprecated. Instead you should use produceWithKey/consumeWith (#15)
+- We can now export the phase cache at will. This is very useful for debugging or for Data Broker testing. Added a method PhasedTestManager.fetchExportFile which help return the selected export file (#8)
+
+## 7.0.0
+- Migrated to TestNG 7.4
+
+## 1.0.0
+- First Release

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The mutational test methods help solve problems such as:
 
 ## Table of Contents
 <!-- TOC -->
+  * [Architecture](#architecture)
   * [Problem Statement](#problem-statement)
     * [Events](#events)
       * [Interruptive Events](#interruptive-events)
@@ -26,25 +27,21 @@ The mutational test methods help solve problems such as:
     * [Default Mode](#default-mode)
     * [Single Execution Mode](#single-execution-mode)
     * [Shuffled Execution Mode](#shuffled-execution-mode)
-        * [Shuffled - Interruptive](#shuffled---interruptive)
-        * [Shuffled - Non-Interruptive](#shuffled---non-interruptive)
   * [Event Management and Execution](#event-management-and-execution)
   * [Writing a Phased Test](#writing-a-phased-test)
     * [Setting Execution Modes](#setting-execution-modes)
       * [Shuffled Mode](#shuffled-mode)
       * [Single Run Mode](#single-run-mode)
     * [Local Execution](#local-execution)
-    * [Non-Interruptive Events](#non-interruptive-events)
+    * [Non-Interruptive Events](#non-interruptive-events-1)
       * [Writing a Non-Interruptive Event](#writing-a-non-interruptive-event)
-        * [Performing Event Cleanup Actions](#performing-event-cleanup-actions)
       * [Binding an Event to a Scenario](#binding-an-event-to-a-scenario)
-        * [Attaching an Event using the PhaseEvent Annotation](#attaching-an-event-using-the-phaseevent-annotation)
-        * [Attaching an Event using the PhasedTest Annotation](#attaching-an-event-using-the-phasedtest-annotation)
-        * [Attaching an Event to the Test Suite](#attaching-an-event-to-the-test-suite)
-        * [Targeting an Event to a Specific Step](#targeting-an-event-to-a-specific-step)
     * [Before- and After-Phase Actions](#before--and-after-phase-actions)
     * [Nested Design Pattern](#nested-design-pattern)
-  * [Running a Phased Test](#running-a-phased-test)
+  * [Writing a Mutational Test](#writing-a-mutational-test)
+    * [Defining a scenario](#defining-a-scenario)
+    * [Permutations](#permutations-1)
+  * [Execution Modes and Configuration](#execution-modes-and-configuration)
     * [Execution Modes](#execution-modes)
       * [STANDARD Execution Mode](#standard-execution-mode)
       * [INTERRUPTIVE Execution Mode](#interruptive-execution-mode)
@@ -52,7 +49,7 @@ The mutational test methods help solve problems such as:
       * [PERMUATIONAL Execution Mode](#permuational-execution-mode)
     * [Run Time Properties](#run-time-properties)
       * [MUTATIONAL.EXECUTION.MODE](#mutationalexecutionmode)
-      * [PHASED.TESTS.PHASE (DEPRECATED)](#phasedtestsphase--deprecated-)
+      * [PHASED.TESTS.PHASE (DEPRECATED)](#phasedtestsphase-deprecated)
       * [PHASED.EVENTS.NONINTERRUPTIVE](#phasedeventsnoninterruptive)
       * [PHASED.TESTS.DATABROKER](#phasedtestsdatabroker)
       * [PHASED.TESTS.STORAGE.PATH](#phasedtestsstoragepath)
@@ -83,21 +80,36 @@ The mutational test methods help solve problems such as:
     * [Parallel Testing](#parallel-testing)
     * [Retry Mechanisms](#retry-mechanisms)
   * [Release Notes](#release-notes)
-    * [9.0.0 - In-Progress](#900---in-progress)
-    * [8.11.2](#8112)
-    * [8.11.1](#8111)
-    * [8.0.0](#800)
-    * [7.0.10](#7010)
-    * [7.0.9](#709)
-    * [7.0.8](#708)
-    * [7.0.7](#707)
-    * [7.0.5](#705)
-    * [7.0.4](#704)
-    * [7.0.3](#703)
-    * [7.0.0](#700)
-    * [1.0.0](#100)
 <!-- TOC -->
  
+## Architecture
+As of version 10.0.0, this repository is a multi-module Maven build. There are two ways to *author* a
+mutational test scenario, sharing one common engine:
+
+```
+phased-testing-core          (shared engine: scenario/step management, execution modes,
+                               produce/consume, events, reporting — no authoring-model opinion)
+        ^                              ^
+        |                              |
+phased-testing-testng          phased-testing-mutational
+(annotation-driven authoring:  (inheritance/template-method authoring:
+ @PhasedTest, @PhaseEvent,      extend `Mutational`, plain step methods,
+ PhasedTestListener)            MutationListener)
+```
+
+* **`phased-testing-testng`** is the original, annotation-driven authoring style: you write a plain class,
+  annotate it `@PhasedTest`, and TestNG discovers and runs each `@Test` step method directly. This is
+  documented in [Writing a Phased Test](#writing-a-phased-test).
+* **`phased-testing-mutational`** is a newer, inheritance/template-method authoring style: your test class
+  extends `Mutational`, its step methods are plain (non-`@Test`) methods, and a single template method
+  drives their execution — including running them in every valid permutation. This is documented in
+  [Writing a Mutational Test](#writing-a-mutational-test).
+* Both styles share the same underlying engine (`phased-testing-core`): the same execution modes, the same
+  `produce`/`consume` context API, the same event model, and the same reporting.
+
+You only need to depend on the module matching the authoring style you use — see [Installation](#installation).
+Neither `phased-testing-testng` nor `phased-testing-mutational` depends on the other.
+
 ## Problem Statement
 Mutational Tests (aka Phased Tests) is a framework, built upon TestNG, that allows test scenarios to "mutate". This means that a given scenario can, when needed,change its structure and order, i.e. “mutate”, to address the challenges that are imposed on it.
 
@@ -299,6 +311,23 @@ For now we identify two different event wrappings:
 There are other wrappings, and we will eventually publish them at a later time.
 
 ## Writing a Phased Test
+This is the annotation-driven authoring model, provided by the `phased-testing-testng` module. Your test
+class is a plain TestNG class discovered and run directly by TestNG.
+
+You need to register `PhasedTestListener` for phased tests to be recognized, either on your suite in
+`testng.xml`:
+
+```xml
+<suite name="My Suite">
+    <listeners>
+        <listener class-name="com.adobe.campaign.tests.integro.phased.PhasedTestListener"/>
+    </listeners>
+    ...
+</suite>
+```
+
+or with the `@Listeners` annotation on your test class.
+
 The Phased Testing is activated using two annotations:
 * **@PhasedTest** : Class level annotation. Allows you to control how the test should be executed
 * **@PhaseEvent** : Method level annotation. By setting it you tell the system at which step does the phase event happen. The tests will stop at that point.
@@ -538,8 +567,77 @@ public class PhasedTestSeries_NestedContainer {
 }
 ```
 
-## Running a Phased Test
-We are able to run tests in phases since each step stores the information needed for the following steps. For now this is done at the discretion of the developer. This storage is important as it helps us keep track of the tests:
+## Writing a Mutational Test
+This is the inheritance/template-method authoring model, provided by the `phased-testing-mutational`
+module. Unlike a Phased Test, your test class isn't a plain TestNG class run directly by TestNG — it
+extends the abstract class `Mutational`, and a single template method on that base class (`scenario`)
+resolves the right step order and invokes your step methods one by one, reflectively.
+
+You need to register `MutationListener` for Mutational tests to be recognized, either on your suite in
+`testng.xml`:
+
+```xml
+<suite name="My Suite">
+    <listeners>
+        <listener class-name="com.adobe.campaign.tests.integro.phased.MutationListener"/>
+    </listeners>
+    ...
+</suite>
+```
+
+or with the `@Listeners` annotation on your test class.
+
+### Defining a scenario
+Extend `Mutational`, and write your steps as plain (non-`@Test`) public methods, each accepting a single
+`String` argument — the current phase/shuffle group. You still need a class-level `@Test` annotation (for
+grouping, same as any TestNG class), but you do **not** need `@PhasedTest`/`@PhaseEvent` — `Mutational`
+itself already carries the annotation wiring your steps need.
+
+```java
+@Test(groups = "checkout")
+public class ShoppingCartScenario extends Mutational {
+
+    public void loginToSite(String phaseGroup) {
+        PhasedTestManager.produce("authToken", "123456");
+    }
+
+    public void searchProduct(String phaseGroup) {
+        PhasedTestManager.produce("product", "product1");
+    }
+
+    public void addProductToCart(String phaseGroup) {
+        String product = PhasedTestManager.consume("product");
+        PhasedTestManager.produce("cart", "cart1");
+    }
+
+    public void checkout(String phaseGroup) {
+        PhasedTestManager.consume("authToken");
+        PhasedTestManager.consume("cart");
+    }
+}
+```
+
+Key differences from [Writing a Phased Test](#writing-a-phased-test):
+* Step methods are **not** annotated `@Test` individually — they're plain methods discovered via reflection
+  and invoked one by one by `Mutational.scenario(String)`.
+* Each step method must accept exactly one `String` argument — the current phase/shuffle group.
+* The `produce`/`consume` context API (`PhasedTestManager.produce`/`consume`) is exactly the same as in
+  Phased Testing, since both authoring styles share the same core engine.
+* Ordering between steps is always determined from code-detected dependencies between steps (via
+  `produce`/`consume`) — the same underlying mechanism Phased Tests can opt into via
+  [`PHASED.TESTS.DETECT.ORDER`](#phasedtestsdetectorder), but for Mutational tests it's not optional,
+  since there's no TestNG-native `@Test` method order to fall back on.
+
+### Permutations
+The [PERMUTATIONAL execution mode](#permuational-execution-mode) is the feature most specific to
+Mutational Testing: instead of picking a single valid step order, it identifies every dependency between
+steps (via `produce`/`consume`) and re-executes the scenario once per valid permutation of that order. See
+[Permutations](#permutations) for the underlying concept.
+
+## Execution Modes and Configuration
+This chapter covers the shared engine configuration used by both authoring styles — Phased and
+Mutational tests are both executed and configured the same way. We are able to run tests in phases since
+each step stores the information needed for the following steps. For now this is done at the discretion of the developer. This storage is important as it helps us keep track of the tests:
 
 ![The storage of test cache](diagrams/PhasedDiagrams-General-Process.png)
 
@@ -776,88 +874,4 @@ For now, we do not know how parallel execution will work with phased tests. So i
 For now, we have not come around to deciding how retry should work in the case of phased tests. By default, we deactivate them on the phased tests unless the user specifically chooses to activate them by setting the system property `PHASED.TESTS.RETRY.DISABLED` to false. 
 
 ## Release Notes
-
-### 10.0.0
-* **(breaking change)** [#224 Split the project into a multi-module project](https://github.com/adobe/phased-testing/issues/224). The project is now a multi-module Maven build: `phased-testing-core` (shared engine), `phased-testing-testng` (annotation-driven authoring, same artifact coordinates as before), and `phased-testing-mutational` (new artifact, inheritance/template-method authoring). If you only use the classic `@PhasedTest` annotation model, no changes are required beyond bumping the version. If you use `Mutational`/`MutationListener`, you now need to add a dependency on `phased-testing-mutational` explicitly — see [Installation](#installation).
-* **(breaking change)** The internal package `com.adobe.campaign.tests.integro.phased.permutational` has been renamed to `com.adobe.campaign.tests.integro.phased.stepdependencies`. This only affects code that directly imports classes from that package (`ScenarioStepDependencies`, `ScenarioStepDependencyFactory`, `StepDependencies`), not typical library usage.
-* **(breaking change)** The exception `MutationRampUpException` has been renamed to `ExecutionModeConfigurationException`, since it is thrown for a generic invalid-execution-mode configuration error, unrelated to Mutational Testing specifically.
-
-### 9.0.0 - In-Progress
-* **(new feature)** [#204 Introduction of the Execution Mode replacing Phases](https://github.com/adobe/phased-testing/issues/204). We have revised the way we execute scenarios, as we no longer only cater to Upgrade tests. The means you should revise the way you execute Phased Tests by using Execution Modes. For more information please refer to the chapter [Execution Modes](#execution-modes).
-* **(new feature)** [#35 Adding the Permutation Execution Mode](https://github.com/adobe/phased-testing/issues/35). We have introduced the Permutation Execution Mode. This mode executes a scenario with all possible permutations it can have. This is done by identifying the dependencies between each step, and creating the possible orders of that scenario. For more information please refer to the chapters [Permutation Execution Mode](#permutation-execution-mode).
-* **(new feature)** [#197 Adding the event wrappings to a step](https://github.com/adobe/phased-testing/issues/197). We have now introduced the different wrappings an event can have around a test step. Wrappings can be set in different ways: Execution Mode, Event annotation (in progress), The Phased Test Annotation. 
-
-* **New Environment Variables**
-* MUTATIONAL.EXECUTION.MODE : This property is used to set the execution mode of the Mutational Tests. The value can be one of the following: STANDARD, INTERRUPTIVE(PRODUCER), INTERRUPTIVE(CONSUMER), NON-INTERRUPTIVE, PERMUATIONAL. This will replace the PHASED.TESTS.PHASE property which will be removed in 9.X.3.
-* MUTATIONAL.EVENTS.TARGET : This property allows us to run a single event on a specific step of a scenario. The notation is either the standard method reference, or that of Surefire.  
-
-### 8.11.2
-* **(new feature)** [#178 Allowing the injection in any step of a scenario](https://github.com/adobe/phased-testing/issues/178). We can now inject an event into a step in an arbitrary phased test. This is done by setting the syetm property PHASED.EVENTS.TARGET. This way you can inject the event into that step.
-* **(new feature)** [#198 Adding Post Step Event actions](https://github.com/adobe/phased-testing/issues/198). We allow you to define a 'tearDownEvent' tool to allow you to put the system back to a normal state after the event has finished. Please refer to the chapter [Performing Event Cleanup Actions](#performing-event-cleanup-actions).
-
-### 8.11.1
-* Renaming ConfigValueHandler to ConfigValueHandlerPhased
-* Migrating to Java 11
-* Upgrading the TestNG library to 7.8.0
-
-### 8.0.0
-* [Non-Interrupted Events](#Shuffled---Non-Interruptive)
-* [#112](https://github.com/adobe/phased-testing/issues/112) Technical : Extracted the execution properties to the class ConfigValueHandler.
-* [#115](https://github.com/adobe/phased-testing/issues/115) Fixed bug where the Non-Phased execution was stored as SINGLE-RUN. You can still keep the old behaviour by passing the property "PHASED.TESTS.NONPHASED.LEGACY" to "true". However by default they are stored as "phased-default".
-* [#114](https://github.com/adobe/phased-testing/issues/114) Technical : The methods PhasedTestManager.isPhasedTestShuffledMode & PhasedTestManager.isPhasedTestSingleMode no longer take into account the current phase. Instead, they simply return the information about wether or not the given method/class is Shuffled or Single Mode.
-* [Implementation of execution order detection base on the code.](#Execution-Order) We now have two options:
-  * We continue as before, where we select the order alphabetically.
-  * Whenever the system property, PHASED.TESTS.DETECT.ORDER is set, the steps are executed in the order the way we declared in the code. By default, we expect the coe to be in maven where the tests are in the directory src/test/java. However, this can be overriden by setting the eecution property PHASED.TESTS.CODE.ROOT (#5)
-* [#116](https://github.com/adobe/phased-testing/issues/116) We are now removing the explicite "SingleRun" mode. 
-  * All Phased Tests without a @PhaseEvent annotation next to a step are now considered as "Shuffled".
-  * Any Phased Test with a @PhaseEvent annotation is a Singe Run test.
-  * We have now deprecated the @PhasedTest "canShuffle" attribute.
-
-### 7.0.10
-- Reports are now merged by default (#56)
-- Refactoring : cleaning up cyclomatic complexity in the code (#49).
-- Fixed issue with the listener managing data providers for non-Phased tests (#75).
-
-### 7.0.9
-- Upgraded to TestNG 7.5
-- Resolved case of Skip due to config issues, such as a failure in a BeforePhase method (#41)
-- We no longer throw SkipExceptions in the OnStartTest. Instead, we set the status to Skipped (#42) 
-- Consumer results can now contain the results of the PRODUCER phase (#34) 
-- Storing duration and the phase in the scenario state (#36) 
-- Updated Log4J to 2.17.1 to resolve security issues (#38)
-- Implemented the new select tests to run based on the producer phase (#9)
-- Solved case when the users really wants to use retry. In this case we do not interrupt the retry mechanism.
-- Moved back to java 8. We now compile the artefacts in java 8. This is because our main users are not yet in higher java versions.
-- Removed the deprecated methods `PhasedTestManager.produceWithKey` and `PhasedTestManager.consumeWithKey`. 
-
-### 7.0.8
-- Upgraded java version to Java 11
-- Activated sonar scans
-- Solved Sonar highlighted bugs #20, #21, #23, #24
-- Fixed issue #28 where the skip message when no steps have been executed previously for the current scenario phase group happens
-
-### 7.0.7
-- Migrated to the public git repository.
-
-### 7.0.5
-- You can now define Phase setup methods. `@BeforePhase` & `@AfterPhase` can be set on a normal TestNG Before and After method. The method will then be executed in before or after a phase starts. (#40) 
-- We now allow for user defined data providers in a phased test. For the data provider to be considered, it needs to be declared at class level and not at method level. (#26)
-- We can now configure the reports to include the data providers.
-- We now throw an error if the arguments of the phased steps do not correspond to expected number of parameters (phased + user defined) (#28 & #27 & #38)
-- Solved issue with tests continuing in consumer mode even if their steps had not been executed in the producer phase
-
-### 7.0.4
-- Introduced the Report by Phase Group Functionality (#5)
-- Allowing users to configure the Merged Reports
-- Other issues corrected are : #20, #22, #23, #24, #25
-
-### 7.0.3
-- Renamed old produce/consume to produceInStep/consumeFromStep. The old produceWithKey/consumeWith key are now deprecated. Instead you should use produceWithKey/consumeWith (#15) 
-- We can now export the phase cache at will. This is very useful for debugging or for Data Broker testing. Added a method PhasedTestManager.fetchExportFile which help return the selected export file (#8)
-
-### 7.0.0
-- Migrated to TestNG 7.4
-
-### 1.0.0
-- First Release
-
+See [CHANGELOG.md](CHANGELOG.md) for the full version history.


### PR DESCRIPTION
## Summary

Follow-up to the issue #224 module split. Per discussion, docs are managed as a single root README (this repo is still one project, not independently maintained repos), with the version history extracted into its own file.

- **Extracted `CHANGELOG.md`** — the full release-notes history moves out of the README into its own file; README's Release Notes section is now a one-line pointer.
- **New `## Architecture` section** — explains the 4-module split (`phased-testing-core`/`-testng`/`-mutational`/`-test-fixtures`) and which module to depend on for which authoring style, before diving into concepts.
- **New `## Writing a Mutational Test` section** — this authoring style had no dedicated guide before (only generic "Mutational" branding woven through the Phased-Testing-era docs). Grounded in `Mutational.java`/`MutationListener.java`: extending `Mutational`, plain (non-`@Test`) step methods, how ordering/permutations work, and how it differs from a Phased Test.
- **Listener registration snippets** — both "Writing a Phased Test" and "Writing a Mutational Test" now explicitly show the `testng.xml` `<listener>` registration, which was previously undocumented for either.
- **Renamed** "Running a Phased Test" → "Execution Modes and Configuration", with a note that it's shared engine behavior (execution modes, config properties) used by both authoring styles, not phased-only.
- Regenerated the Table of Contents to match.

No code changes.

## Test plan
- [x] `mvn license:check` passes (README.md/CHANGELOG.md are excluded from header checks)
- [x] Verified all new/renamed section anchors in the regenerated TOC resolve correctly (GitHub slug algorithm)
- [x] Manually reviewed the new "Writing a Mutational Test" content against `Mutational.java` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)