### PR TITLE
Correct next version to 9.0.0, not 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
 
-## 10.0.0
+## 9.0.0 - In-Progress
 * **(breaking change)** [#224 Split the project into a multi-module project](https://github.com/adobe/phased-testing/issues/224). The project is now a multi-module Maven build: `phased-testing-core` (shared engine), `phased-testing-testng` (annotation-driven authoring, same artifact coordinates as before), and `phased-testing-mutational` (new artifact, inheritance/template-method authoring). If you only use the classic `@PhasedTest` annotation model, no changes are required beyond bumping the version. If you use `Mutational`/`MutationListener`, you now need to add a dependency on `phased-testing-mutational` explicitly — see [Installation](README.md#installation).
 * **(breaking change)** The internal package `com.adobe.campaign.tests.integro.phased.permutational` has been renamed to `com.adobe.campaign.tests.integro.phased.stepdependencies`. This only affects code that directly imports classes from that package (`ScenarioStepDependencies`, `ScenarioStepDependencyFactory`, `StepDependencies`), not typical library usage.
 * **(breaking change)** The exception `MutationRampUpException` has been renamed to `ExecutionModeConfigurationException`, since it is thrown for a generic invalid-execution-mode configuration error, unrelated to Mutational Testing specifically.
-
-## 9.0.0 - In-Progress
 * **(new feature)** [#204 Introduction of the Execution Mode replacing Phases](https://github.com/adobe/phased-testing/issues/204). We have revised the way we execute scenarios, as we no longer only cater to Upgrade tests. The means you should revise the way you execute Phased Tests by using Execution Modes. For more information please refer to the chapter [Execution Modes](README.md#execution-modes).
 * **(new feature)** [#35 Adding the Permutation Execution Mode](https://github.com/adobe/phased-testing/issues/35). We have introduced the Permutation Execution Mode. This mode executes a scenario with all possible permutations it can have. This is done by identifying the dependencies between each step, and creating the possible orders of that scenario. For more information please refer to the chapters [Permutation Execution Mode](README.md#permutation-execution-mode).
 * **(new feature)** [#197 Adding the event wrappings to a step](https://github.com/adobe/phased-testing/issues/197). We have now introduced the different wrappings an event can have around a test step. Wrappings can be set in different ways: Execution Mode, Event annotation (in progress), The Phased Test Annotation.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The mutational test methods help solve problems such as:
 <!-- TOC -->
  
 ## Architecture
-As of version 10.0.0, this repository is a multi-module Maven build. There are two ways to *author* a
+As of version 9.0.0, this repository is a multi-module Maven build. There are two ways to *author* a
 mutational test scenario, sharing one common engine:
 
 ```
@@ -170,7 +170,7 @@ This is particularily usefull for covering all the possible paths a functional s
 ## Installation
 This version runs with the TestNG runner. You can use this library by including it in your project.
 
-As of version 10.0.0, the project is split into multiple Maven modules sharing a common core engine
+As of version 9.0.0, the project is split into multiple Maven modules sharing a common core engine
 (`phased-testing-core`), so that the annotation-driven "Phased Testing" authoring model and the
 inheritance/template-method-driven "Mutational Testing" authoring model can be released and depended on
 independently. `phased-testing-core` is a transitive dependency of both and does not need to be declared
@@ -185,7 +185,7 @@ If you write tests using the classic `@PhasedTest` annotation model (`PhasedTest
  <dependency>
     <groupId>com.adobe.campaign.tests.phased</groupId>
     <artifactId>phased-testing-testng</artifactId>
-    <version>10.0.0</version>
+    <version>9.0.0</version>
 </dependency>
 ```
 
@@ -196,7 +196,7 @@ If you write tests using the `Mutational` base class (inheritance/template-metho
  <dependency>
     <groupId>com.adobe.campaign.tests.phased</groupId>
     <artifactId>phased-testing-mutational</artifactId>
-    <version>10.0.0</version>
+    <version>9.0.0</version>
 </dependency>
 ```
 

--- a/phased-testing-core/pom.xml
+++ b/phased-testing-core/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.adobe.campaign.tests.phased</groupId>
         <artifactId>phased-testing-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>9.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>phased-testing-core</artifactId>

--- a/phased-testing-mutational/pom.xml
+++ b/phased-testing-mutational/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.adobe.campaign.tests.phased</groupId>
         <artifactId>phased-testing-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>9.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>phased-testing-mutational</artifactId>

--- a/phased-testing-report-aggregate/pom.xml
+++ b/phased-testing-report-aggregate/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.adobe.campaign.tests.phased</groupId>
         <artifactId>phased-testing-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>9.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>phased-testing-report-aggregate</artifactId>

--- a/phased-testing-test-fixtures/pom.xml
+++ b/phased-testing-test-fixtures/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.adobe.campaign.tests.phased</groupId>
         <artifactId>phased-testing-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>9.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>phased-testing-test-fixtures</artifactId>

--- a/phased-testing-testng/pom.xml
+++ b/phased-testing-testng/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.adobe.campaign.tests.phased</groupId>
         <artifactId>phased-testing-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>9.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>phased-testing-testng</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.campaign.tests.phased</groupId>
     <artifactId>phased-testing-parent</artifactId>
-    <version>10.0.0-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
     <description>Parent for the Phased/Mutational Testing framework modules</description>
     <url>https://github.com/adobe/phased-testing</url>
     <packaging>pom</packaging>


### PR DESCRIPTION
## Summary

The changelog already had an unreleased "9.0.0 - In-Progress" entry (Execution Mode / Permutation work) predating the multi-module split work. That work incorrectly bumped to 10.0.0 as a separate release instead of landing as more entries under the existing in-progress 9.0.0.

- Merged the module-split changelog entries into the existing `9.0.0 - In-Progress` entry instead of a separate `10.0.0` one.
- Set version to `9.0.0-SNAPSHOT` in the parent POM and all 5 module POMs.
- Updated the two "As of version" references and the two dependency snippets in README.md from 10.0.0 to 9.0.0.

## Test plan
- [x] `mvn clean test` green across the full reactor
- [x] `grep` sweep confirms no remaining `10.0.0` references anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)