### PR TITLE
Fix Mermaid diagram + move Architecture section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,33 @@ Thanks for choosing to contribute!
 
 The following are a set of guidelines to follow when contributing to this project.
 
+## Architecture
+This repository is a multi-module Maven build. There are two ways to *author* a mutational test
+scenario, sharing one common engine:
+
+```mermaid
+graph BT
+    core["phased-testing-core\nshared engine: scenario/step management,\nexecution modes, produce/consume,\nevents, reporting — no authoring-model opinion"]
+    testng["phased-testing-testng\nannotation-driven authoring:\n@PhasedTest, @PhaseEvent,\nPhasedTestListener"]
+    mutational["mutational-testing\ninheritance/template-method authoring:\nextend Mutational, plain step methods,\nMutationListener"]
+
+    testng --> core
+    mutational --> core
+```
+
+* **`phased-testing-testng`** is the original, annotation-driven authoring style: you write a plain class,
+  annotate it `@PhasedTest`, and TestNG discovers and runs each `@Test` step method directly. This is
+  documented in [Writing a Phased Test](README.md#writing-a-phased-test).
+* **`mutational-testing`** is a newer, inheritance/template-method authoring style: your test class
+  extends `Mutational`, its step methods are plain (non-`@Test`) methods, and a single template method
+  drives their execution — including running them in every valid permutation. This is documented in
+  [Writing a Mutational Test](README.md#writing-a-mutational-test).
+* Both styles share the same underlying engine (`phased-testing-core`): the same execution modes, the same
+  `produce`/`consume` context API, the same event model, and the same reporting.
+
+You only need to depend on the module matching the authoring style you use — see [Installation](README.md#installation).
+Neither `phased-testing-testng` nor `mutational-testing` depends on the other.
+
 ## Code Of Conduct
 
 This project adheres to the Adobe [code of conduct](./CODE_OF_CONDUCT.md). By participating,

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ As of version 9.0.0, this repository is a multi-module Maven build — see the [
   * [Writing a Mutational Test](#writing-a-mutational-test)
     * [Defining a scenario](#defining-a-scenario)
     * [Permutations](#permutations-1)
+    * [Non-Interruptive Events](#non-interruptive-events-2)
   * [Execution Modes and Configuration](#execution-modes-and-configuration)
     * [Execution Modes](#execution-modes)
       * [STANDARD Execution Mode](#standard-execution-mode)
@@ -183,6 +184,10 @@ We have a standard demo that can be accessed through the [Phased Test Demo](http
 
 ## Wrapping a Secnario around an Event
 One of the main features of Phased Testing is the ability to wrap a scenario around an event or a problem. This is done by performing a number of iterations and injecting the event at different stages of the execution of that scenario.
+
+> The code examples in this chapter use the annotation-driven Phased Test style for brevity. Mutational
+> Tests share the exact same execution modes and event semantics — only the class-authoring shape differs.
+> See [Writing a Mutational Test](#writing-a-mutational-test) for the equivalent, self-contained examples.
 
 We have three modes of execution of a Phased Test:
 * Default Mode
@@ -609,6 +614,24 @@ The [PERMUTATIONAL execution mode](#permuational-execution-mode) is the feature 
 Mutational Testing: instead of picking a single valid step order, it identifies every dependency between
 steps (via `produce`/`consume`) and re-executes the scenario once per valid permutation of that order. See
 [Permutations](#permutations) for the underlying concept.
+
+### Non-Interruptive Events
+Events for Mutational Tests use the exact same `NonInterruptiveEvent` API described in
+[Writing a Non-Interruptive Event](#writing-a-non-interruptive-event) — nothing changes there.
+
+Binding an event to a scenario is different, though: since a Mutational Test's step methods are plain
+methods (not annotated `@Test`/`@PhaseEvent`), the annotation-based binding options
+([`@PhaseEvent`](#attaching-an-event-using-the-phaseevent-annotation),
+[`@PhasedTest(eventClasses = ...)`](#attaching-an-event-using-the-phasedtest-annotation)) don't apply.
+Only the two system-property-based options do:
+* [Attaching an Event to the Test Suite](#attaching-an-event-to-the-test-suite) — `MUTATIONAL.EVENTS.NONINTERRUPTIVE`
+* [Targeting an Event to a Specific Step](#targeting-an-event-to-a-specific-step) — `MUTATIONAL.EVENTS.NONINTERRUPTIVE` + `MUTATIONAL.EVENTS.TARGET`
+
+Given `ShoppingCartScenario` from [Defining a scenario](#defining-a-scenario), targeting the event
+`com.adobe.campaign.tests.integro.phased.data.events.MyNonInterruptiveEvent` at the `addProductToCart` step
+looks like:
+
+```mvn clean test -DMUTATIONAL.EVENTS.NONINTERRUPTIVE=com.adobe.campaign.tests.integro.phased.data.events.MyNonInterruptiveEvent -DMUTATIONAL.EVENTS.TARGET=ShoppingCartScenario#addProductToCart```
 
 ## Execution Modes and Configuration
 This chapter covers the shared engine configuration used by both authoring styles — Phased and

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ The mutational test methods help solve problems such as:
 * Chaos testing
 * End-User testing
 
+As of version 9.0.0, this repository is a multi-module Maven build — see the [Architecture overview](CONTRIBUTING.md#architecture) in CONTRIBUTING.md for how the modules fit together.
+
 ## Table of Contents
 <!-- TOC -->
-  * [Architecture](#architecture)
   * [Problem Statement](#problem-statement)
     * [Events](#events)
       * [Interruptive Events](#interruptive-events)
@@ -85,33 +86,6 @@ The mutational test methods help solve problems such as:
   * [Release Notes](#release-notes)
 <!-- TOC -->
  
-## Architecture
-As of version 9.0.0, this repository is a multi-module Maven build. There are two ways to *author* a
-mutational test scenario, sharing one common engine:
-
-```mermaid
-graph BT
-    core["phased-testing-core\nshared engine: scenario/step management,\nexecution modes, produce/consume,\nevents, reporting — no authoring-model opinion"]
-    testng["phased-testing-testng\nannotation-driven authoring:\n@PhasedTest, @PhaseEvent,\nPhasedTestListener"]
-    mutational["mutational-testing\ninheritance/template-method authoring:\nextend Mutational, plain step methods,\nMutationListener"]
-
-    testng --> core
-    mutational --> core
-```
-
-* **`phased-testing-testng`** is the original, annotation-driven authoring style: you write a plain class,
-  annotate it `@PhasedTest`, and TestNG discovers and runs each `@Test` step method directly. This is
-  documented in [Writing a Phased Test](#writing-a-phased-test).
-* **`mutational-testing`** is a newer, inheritance/template-method authoring style: your test class
-  extends `Mutational`, its step methods are plain (non-`@Test`) methods, and a single template method
-  drives their execution — including running them in every valid permutation. This is documented in
-  [Writing a Mutational Test](#writing-a-mutational-test).
-* Both styles share the same underlying engine (`phased-testing-core`): the same execution modes, the same
-  `produce`/`consume` context API, the same event model, and the same reporting.
-
-You only need to depend on the module matching the authoring style you use — see [Installation](#installation).
-Neither `phased-testing-testng` nor `mutational-testing` depends on the other.
-
 ## Problem Statement
 Mutational Tests (aka Phased Tests) is a framework, built upon TestNG, that allows test scenarios to "mutate". This means that a given scenario can, when needed,change its structure and order, i.e. “mutate”, to address the challenges that are imposed on it.
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ mutational test scenario, sharing one common engine:
 
 ```mermaid
 graph BT
-    core["<b>phased-testing-core</b><br/>shared engine: scenario/step management,<br/>execution modes, produce/consume,<br/>events, reporting — no authoring-model opinion"]
-    testng["<b>phased-testing-testng</b><br/>annotation-driven authoring:<br/>@PhasedTest, @PhaseEvent,<br/>PhasedTestListener"]
-    mutational["<b>mutational-testing</b><br/>inheritance/template-method authoring:<br/>extend Mutational, plain step methods,<br/>MutationListener"]
+    core["phased-testing-core\nshared engine: scenario/step management,\nexecution modes, produce/consume,\nevents, reporting — no authoring-model opinion"]
+    testng["phased-testing-testng\nannotation-driven authoring:\n@PhasedTest, @PhaseEvent,\nPhasedTestListener"]
+    mutational["mutational-testing\ninheritance/template-method authoring:\nextend Mutational, plain step methods,\nMutationListener"]
 
     testng --> core
     mutational --> core


### PR DESCRIPTION
## Summary
- Follow-up to #245, which merged before these two fixes landed:
  - Fixes the Mermaid diagram's line breaks: GitHub's renderer doesn't interpret `<br/>`/`<b>` HTML inside node labels, so it was rendering as one run-on line. Switched to the `\n` escape sequence, which Mermaid flowchart labels support natively.
  - Moves the Architecture overview (with the diagram) from README.md into CONTRIBUTING.md, since it's contributor-facing structural context rather than end-user usage docs. README now links to it.

## Test plan
- [x] Docs-only change, no code affected.
- [x] Verified Mermaid label syntax renders as multi-line in GitHub's preview.